### PR TITLE
Add encryption features: encrypted fields and secure routing

### DIFF
--- a/ArgumentResolver/EncryptedIdValueResolver.php
+++ b/ArgumentResolver/EncryptedIdValueResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Redking\ParseBundle\ArgumentResolver;
+
+use Redking\ParseBundle\Attribute\EncryptedId;
+use Redking\ParseBundle\ObjectManager;
+use Redking\ParseBundle\Security\EncryptionService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Resolves controller arguments marked with the EncryptedId attribute
+ *
+ * This resolver:
+ * 1. Detects route parameters marked with #[EncryptedId]
+ * 2. Decrypts the parameter value using EncryptionService
+ * 3. Loads the corresponding Parse object from the database
+ * 4. Returns the entity instance for injection into the controller
+ *
+ * @see EncryptedId
+ */
+class EncryptedIdValueResolver implements ValueResolverInterface
+{
+    public function __construct(
+        private readonly ObjectManager $om,
+        private readonly EncryptionService $encryptionService
+    ) {}
+
+    /**
+     * @return iterable<object>
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        // Check if the argument has the EncryptedId attribute
+        $attributes = $argument->getAttributes(EncryptedId::class, ArgumentMetadata::IS_INSTANCEOF);
+        if (empty($attributes)) {
+            return [];
+        }
+
+        // Get the encrypted value from the route
+        $encryptedId = $request->attributes->get($argument->getName());
+        if (!$encryptedId) {
+            return [];
+        }
+
+        /** @var EncryptedId $attribute */
+        $attribute = $attributes[0];
+
+        // Decrypt the ID
+        $id = $this->encryptionService->decrypt($encryptedId);
+
+        if (!$id) {
+            throw new NotFoundHttpException('Invalid encrypted ID.');
+        }
+
+        // Load the entity
+        $entity = $this->om->getRepository($attribute->class)->find($id);
+
+        if (!$entity) {
+            throw new NotFoundHttpException(
+                sprintf('No entity "%s" found for ID "%s".', $attribute->class, $id)
+            );
+        }
+
+        return [$entity];
+    }
+}

--- a/ArgumentResolver/LegacyEncryptedIdValueResolver.php
+++ b/ArgumentResolver/LegacyEncryptedIdValueResolver.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Redking\ParseBundle\ArgumentResolver;
+
+use Redking\ParseBundle\Attribute\EncryptedId;
+use Redking\ParseBundle\ObjectManager;
+use Redking\ParseBundle\Security\EncryptionService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Resolves controller arguments marked with the EncryptedId attribute (Symfony 5.4 compatible)
+ *
+ * This resolver:
+ * 1. Detects route parameters marked with #[EncryptedId]
+ * 2. Decrypts the parameter value using EncryptionService
+ * 3. Loads the corresponding Parse object from the database
+ * 4. Returns the entity instance for injection into the controller
+ *
+ * @see EncryptedId
+ */
+class LegacyEncryptedIdValueResolver implements ArgumentValueResolverInterface
+{
+    private ObjectManager $om;
+    private EncryptionService $encryptionService;
+
+    public function __construct(
+        ObjectManager $om,
+        EncryptionService $encryptionService
+    ) {
+        $this->om = $om;
+        $this->encryptionService = $encryptionService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        // Check if the argument has the EncryptedId attribute
+        $attributes = $argument->getAttributes(EncryptedId::class, ArgumentMetadata::IS_INSTANCEOF);
+        if (empty($attributes)) {
+            return false;
+        }
+
+        // Get the encrypted value from the route
+        $encryptedId = $request->attributes->get($argument->getName());
+
+        return !empty($encryptedId);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        // Get the encrypted value from the route
+        $encryptedId = $request->attributes->get($argument->getName());
+        if (!$encryptedId) {
+            return;
+        }
+
+        // Get the EncryptedId attribute
+        $attributes = $argument->getAttributes(EncryptedId::class, ArgumentMetadata::IS_INSTANCEOF);
+        if (empty($attributes)) {
+            return;
+        }
+
+        /** @var EncryptedId $attribute */
+        $attribute = $attributes[0];
+
+        // Decrypt the ID
+        $id = $this->encryptionService->decrypt($encryptedId);
+
+        if (!$id) {
+            throw new NotFoundHttpException('Invalid encrypted ID.');
+        }
+
+        // Load the entity
+        $entity = $this->om->getRepository($attribute->class)->find($id);
+
+        if (!$entity) {
+            throw new NotFoundHttpException(
+                sprintf('No entity "%s" found for ID "%s".', $attribute->class, $id)
+            );
+        }
+
+        yield $entity;
+    }
+}

--- a/Attribute/EncryptedId.php
+++ b/Attribute/EncryptedId.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Redking\ParseBundle\Attribute;
+
+use Attribute;
+
+/**
+ * Used to decrypt object IDs in route parameters
+ *
+ * This attribute marks a route parameter as containing an encrypted Parse object ID.
+ * The EncryptedIdValueResolver will automatically decrypt it and load the corresponding entity.
+ *
+ * Example:
+ * ```php
+ * #[Route('/user/{user}', name: 'user_profile')]
+ * public function profile(#[EncryptedId(User::class)] User $user): Response
+ * {
+ *     // $user is automatically decrypted and loaded
+ * }
+ * ```
+ */
+#[Attribute(Attribute::TARGET_PARAMETER)]
+class EncryptedId
+{
+    /**
+     * @param string $class The fully qualified class name of the Parse object
+     */
+    public function __construct(
+        public readonly string $class
+    ) {}
+}

--- a/DependencyInjection/RedkingParseExtension.php
+++ b/DependencyInjection/RedkingParseExtension.php
@@ -157,6 +157,14 @@ class RedkingParseExtension extends AbstractDoctrineExtension
         $omDef->setFactory(['Redking\ParseBundle\ObjectManager', 'create']);
         $omDef->addTag('doctrine_parse.object_manager');
         $omDef->setPublic(true);
+
+        // Initialize EncryptionService for EncryptedStringType
+        if ($container->hasDefinition('doctrine.parse.encryption_service')) {
+            $omDef->addMethodCall('initializeEncryptionType', [
+                new Reference('doctrine.parse.encryption_service')
+            ]);
+        }
+
         $container->setDefinition('redking_parse.manager', $omDef);
 
         $container->setAlias('doctrine.parse.object_manager', 'redking_parse.manager');

--- a/DependencyInjection/RedkingParseExtension.php
+++ b/DependencyInjection/RedkingParseExtension.php
@@ -171,6 +171,7 @@ class RedkingParseExtension extends AbstractDoctrineExtension
         $container->getAlias('doctrine.parse.object_manager')->setPublic(true);
 
         $this->loadEntityValueResolverServices($container, $config);
+        $this->loadEncryptedIdValueResolver($container);
     }
 
     /**
@@ -427,5 +428,42 @@ class RedkingParseExtension extends AbstractDoctrineExtension
             null,
             $controllerResolverDefaults['disabled'] ?? false,
         ]));
+    }
+
+    /**
+     * Load the appropriate EncryptedIdValueResolver based on Symfony version
+     */
+    private function loadEncryptedIdValueResolver(ContainerBuilder $container): void
+    {
+        // Check if ValueResolverInterface exists (Symfony 6.2+)
+        if (interface_exists('Symfony\Component\HttpKernel\Controller\ValueResolverInterface')) {
+            // Use modern ValueResolverInterface (Symfony 6.2+)
+            $resolverDef = new Definition(
+                'Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver',
+                [
+                    new Reference('redking_parse.manager'),
+                    new Reference('doctrine.parse.encryption_service')
+                ]
+            );
+            $resolverDef->addTag('controller.argument_value_resolver', [
+                'name' => 'Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver',
+                'priority' => 111
+            ]);
+        } else {
+            // Use legacy ArgumentValueResolverInterface (Symfony 5.4)
+            $resolverDef = new Definition(
+                'Redking\ParseBundle\ArgumentResolver\LegacyEncryptedIdValueResolver',
+                [
+                    new Reference('redking_parse.manager'),
+                    new Reference('doctrine.parse.encryption_service')
+                ]
+            );
+            $resolverDef->addTag('controller.argument_value_resolver', [
+                'priority' => 111
+            ]);
+        }
+
+        $resolverDef->setPublic(false);
+        $container->setDefinition('doctrine.parse.encrypted_id_value_resolver', $resolverDef);
     }
 }

--- a/Hydrator/ParseObjectHydrator.php
+++ b/Hydrator/ParseObjectHydrator.php
@@ -66,12 +66,17 @@ class ParseObjectHydrator
             if ($data->has($mapping['name']) && !isset($mapping['reference'])) {
                 if ($mapping['type'] === Type::GEOPOINT && null !== $data->get($mapping['name'])) {
                     $this->class->reflFields[$key]->setValue($object, clone $data->get($mapping['name']));
+                } elseif ($mapping['type'] === Type::ENCRYPTED_STRING) {
+                    // Decrypt encrypted string field
+                    $type = \Redking\ParseBundle\Types\Type::getType(Type::ENCRYPTED_STRING);
+                    $decrypted = $type->convertToPHPValue($data->get($mapping['name']));
+                    $this->class->reflFields[$key]->setValue($object, $decrypted);
                 } else {
                     $this->class->reflFields[$key]->setValue($object, $data->get($mapping['name']));
                 }
             }
             // reset value if doctrine refresh
-            elseif (isset($hints['doctrine.refresh']) 
+            elseif (isset($hints['doctrine.refresh'])
                 && !in_array($key, ['id', 'createdAt', 'updatedAt'])
                 && !isset($mapping['reference'])
                 && null !== $this->class->reflFields[$key]->getValue($object)) {

--- a/ObjectManager.php
+++ b/ObjectManager.php
@@ -11,6 +11,8 @@ use Parse\ParseStorageInterface;
 use Redking\ParseBundle\Mapping\ClassMetadata;
 use Redking\ParseBundle\Mapping\ClassMetadataFactory;
 use Redking\ParseBundle\Proxy\ProxyFactory;
+use Redking\ParseBundle\Security\EncryptionService;
+use Redking\ParseBundle\Types\EncryptedStringType;
 
 class ObjectManager implements BaseObjectManager
 {
@@ -95,6 +97,19 @@ class ObjectManager implements BaseObjectManager
     public static function create(Configuration $config = null, EventManager $eventManager = null, ParseStorageInterface $parseStorage = null): self
     {
         return new static($config, $eventManager, $parseStorage);
+    }
+
+    /**
+     * Initialize EncryptionService for EncryptedStringType
+     *
+     * This method is called by the DI container to inject the encryption service
+     * into the EncryptedStringType class.
+     *
+     * @param EncryptionService $encryptionService
+     */
+    public function initializeEncryptionType(EncryptionService $encryptionService): void
+    {
+        EncryptedStringType::setEncryptionService($encryptionService);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ in this bundle :
 - [**Persistence**](Resources/doc/persistence.md)
 - [**Events**](Resources/doc/events.md)
 - [**QueryBuilder**](Resources/doc/query_builder.md)
+- [**Encrypted Routing**](Resources/doc/encrypted_routing.md)
 - [**Form Types**](Resources/doc/form_types.md)
 - [**Symfony Integration**](Resources/doc/symfony_integration.md)
 - [**3d Party Bundles**](Resources/doc/3rd_party.md)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ in this bundle :
 - [**Installation**](Resources/doc/installation.md)
 - [**Configuration**](Resources/doc/configuration.md)
 - [**Mapping**](Resources/doc/mapping.md)
+- [**Field Types**](Resources/doc/types.md)
 - [**Persistence**](Resources/doc/persistence.md)
 - [**Events**](Resources/doc/events.md)
 - [**QueryBuilder**](Resources/doc/query_builder.md)

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -166,4 +166,31 @@ services:
 
     Redking\ParseBundle\Security\EncryptionService: '@doctrine.parse.encryption_service'
 
+    # Encrypted routing
+    doctrine.parse.encrypted_url_generator:
+        class: Redking\ParseBundle\Routing\EncryptedUrlGenerator
+        arguments:
+            - "@router"
+            - "@doctrine.parse.encryption_service"
+        public: false
+
+    Redking\ParseBundle\Routing\EncryptedUrlGenerator: '@doctrine.parse.encrypted_url_generator'
+
+    doctrine.parse.encrypted_id_value_resolver:
+        class: Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver
+        arguments:
+            - "@redking_parse.manager"
+            - "@doctrine.parse.encryption_service"
+        tags:
+            - controller.argument_value_resolver:
+                name: Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver
+                priority: 111
+
+    doctrine.parse.twig.encrypted_url_extension:
+        class: Redking\ParseBundle\Twig\EncryptedUrlExtension
+        arguments:
+            - "@doctrine.parse.encrypted_url_generator"
+        tags:
+            - { name: twig.extension }
+
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -13,6 +13,10 @@ parameters:
     doctrine_parse.fixtures_dirs: []
     doctrine_parse.session_storage.class: 'Redking\ParseBundle\Bridge\Parse\Storage\ParseSessionStorage'
     doctrine.parse.doctrine_cache_warmer.class: 'Redking\ParseBundle\CacheWarmer\DoctrineCacheWarmer'
+    # Encryption parameters
+    doctrine.parse.encryption_key: '%env(default:kernel.secret:string:APP_ENCRYPTION_KEY)%'
+    doctrine.parse.hmac_key: '%env(default:kernel.secret:string:APP_HMAC_KEY)%'
+    doctrine.parse.encryption_encoding: 'base64'
     # Doctrine cache implementations
     doctrine.parse.cache.array.class: Doctrine\Common\Cache\ArrayCache
     doctrine.parse.cache.apc.class: Doctrine\Common\Cache\ApcCache
@@ -150,5 +154,16 @@ services:
             - controller.argument_value_resolver:
                 name: Redking\ParseBundle\ArgumentResolver\ParseObjectValueResolver
                 priority: 110
+
+    # Encryption service
+    doctrine.parse.encryption_service:
+        class: Redking\ParseBundle\Security\EncryptionService
+        arguments:
+            - "%doctrine.parse.encryption_key%"
+            - "%doctrine.parse.hmac_key%"
+            - "%doctrine.parse.encryption_encoding%"
+        public: false
+
+    Redking\ParseBundle\Security\EncryptionService: '@doctrine.parse.encryption_service'
 
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -176,16 +176,6 @@ services:
 
     Redking\ParseBundle\Routing\EncryptedUrlGenerator: '@doctrine.parse.encrypted_url_generator'
 
-    doctrine.parse.encrypted_id_value_resolver:
-        class: Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver
-        arguments:
-            - "@redking_parse.manager"
-            - "@doctrine.parse.encryption_service"
-        tags:
-            - controller.argument_value_resolver:
-                name: Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver
-                priority: 111
-
     doctrine.parse.twig.encrypted_url_extension:
         class: Redking\ParseBundle\Twig\EncryptedUrlExtension
         arguments:

--- a/Resources/doc/encrypted_routing.md
+++ b/Resources/doc/encrypted_routing.md
@@ -1,0 +1,381 @@
+# Encrypted Routing
+
+DoctrineParseBundle provides a secure way to expose Parse object IDs in public URLs by encrypting them. This prevents exposing internal IDs while maintaining routing functionality.
+
+## Why Encrypt IDs?
+
+Exposing raw Parse object IDs in URLs can present security concerns:
+- **Enumeration attacks**: Users can guess IDs and access resources they shouldn't
+- **Information leakage**: Sequential IDs reveal information about your data
+- **Direct object reference**: Makes it easier to tamper with URLs
+
+Encrypted routing solves these issues by:
+- Making IDs unpredictable and non-sequential
+- Preventing enumeration attacks
+- Adding authentication via HMAC to detect tampering
+
+## Configuration
+
+The encrypted routing system uses the same encryption service as encrypted fields. By default, it uses `kernel.secret`, but you can configure custom keys:
+
+```env
+# .env
+APP_ENCRYPTION_KEY=your_32_bytes_encryption_key_here
+APP_HMAC_KEY=your_32_bytes_hmac_key_here
+```
+
+**Important**: For encrypted routing, the system automatically uses `base64url` encoding (URL-safe) instead of standard `base64`.
+
+## Basic Usage
+
+### 1. Mark Controller Parameters with `#[EncryptedId]`
+
+Use the `#[EncryptedId]` attribute on controller parameters to automatically decrypt and load Parse objects:
+
+```php
+<?php
+
+namespace App\Controller;
+
+use App\ParseObject\Post;
+use Redking\ParseBundle\Attribute\EncryptedId;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class PostController extends AbstractController
+{
+    #[Route('/post/{post}', name: 'post_show')]
+    public function show(
+        #[EncryptedId(Post::class)] Post $post
+    ): Response {
+        // $post is automatically decrypted and loaded
+        return $this->render('post/show.html.twig', [
+            'post' => $post,
+        ]);
+    }
+}
+```
+
+### 2. Generate Encrypted URLs
+
+#### Using the Service (in Controllers)
+
+```php
+use Redking\ParseBundle\Routing\EncryptedUrlGenerator;
+
+class PostController extends AbstractController
+{
+    public function __construct(
+        private readonly EncryptedUrlGenerator $urlGenerator
+    ) {}
+
+    public function list(): Response
+    {
+        $posts = $this->om->getRepository(Post::class)->findAll();
+
+        $urls = [];
+        foreach ($posts as $post) {
+            // Generate encrypted URL
+            $urls[$post->getId()] = $this->urlGenerator->generate(
+                'post_show',
+                ['post' => $post->getId()],
+                'post'  // parameter name to encrypt
+            );
+        }
+
+        return $this->render('post/list.html.twig', [
+            'posts' => $posts,
+            'urls' => $urls,
+        ]);
+    }
+}
+```
+
+#### Using Twig Functions (in Templates)
+
+```twig
+{# Generate a relative path with encrypted ID #}
+<a href="{{ encrypted_path('post_show', {'post': post.id}, 'post') }}">
+    View Post
+</a>
+
+{# Generate an absolute URL with encrypted ID #}
+<a href="{{ encrypted_url('post_show', {'post': post.id}, 'post') }}">
+    View Post (Absolute)
+</a>
+```
+
+## Advanced Usage
+
+### Multiple Encrypted Parameters
+
+You can encrypt multiple parameters in a single route:
+
+```php
+#[Route('/user/{user}/post/{post}', name: 'user_post_show')]
+public function showUserPost(
+    #[EncryptedId(User::class)] User $user,
+    #[EncryptedId(Post::class)] Post $post
+): Response {
+    // Both $user and $post are automatically decrypted and loaded
+    return $this->render('post/show.html.twig', [
+        'user' => $user,
+        'post' => $post,
+    ]);
+}
+```
+
+Generate URL with multiple encrypted parameters:
+
+```php
+$url = $this->urlGenerator->generate(
+    'user_post_show',
+    ['user' => $userId, 'post' => $postId],
+    ['user', 'post']  // array of parameters to encrypt
+);
+```
+
+In Twig:
+
+```twig
+<a href="{{ encrypted_path('user_post_show', {'user': user.id, 'post': post.id}, ['user', 'post']) }}">
+    View User's Post
+</a>
+```
+
+### Custom Parameter Names
+
+By default, encrypted parameters are named after the entity parameter in your controller. You can use any parameter name:
+
+```php
+#[Route('/p/{postId}', name: 'post_short')]
+public function short(
+    #[EncryptedId(Post::class)] $postId
+): Response {
+    // Route parameter is 'postId', controller variable is also 'postId'
+    // $postId contains the loaded Post entity
+    return $this->render('post/show.html.twig', ['post' => $postId]);
+}
+```
+
+```php
+// Generate URL
+$url = $this->urlGenerator->generate(
+    'post_short',
+    ['postId' => $post->getId()],
+    'postId'  // matches the route parameter name
+);
+```
+
+### Mixing Encrypted and Non-Encrypted Parameters
+
+You can mix encrypted IDs with regular parameters:
+
+```php
+#[Route('/post/{post}/comments', name: 'post_comments')]
+public function comments(
+    #[EncryptedId(Post::class)] Post $post,
+    int $page = 1
+): Response {
+    // $post is decrypted and loaded
+    // $page is a regular query parameter
+    return $this->render('post/comments.html.twig', [
+        'post' => $post,
+        'page' => $page,
+    ]);
+}
+```
+
+```php
+$url = $this->urlGenerator->generate(
+    'post_comments',
+    ['post' => $postId, 'page' => 2],
+    'post'  // only 'post' is encrypted, 'page' stays plain
+);
+// Result: /post/dGVzdF9lbmNyeXB0ZWRfZGF0YQ.../comments?page=2
+```
+
+## Security Considerations
+
+### 1. Encryption is Non-Deterministic
+
+Each time you encrypt an ID, you get a different encrypted value (due to random IV):
+
+```php
+$encrypted1 = $urlGenerator->generate('post_show', ['post' => 'abc123'], 'post');
+$encrypted2 = $urlGenerator->generate('post_show', ['post' => 'abc123'], 'post');
+
+// $encrypted1 !== $encrypted2 (different encrypted values)
+// But both decrypt to 'abc123'
+```
+
+This prevents attackers from correlating URLs across different contexts.
+
+### 2. Tamper Detection
+
+The encrypted IDs include an HMAC signature. Any tampering is automatically detected:
+
+```php
+// Original URL: /post/dGVzdF9lbmNyeXB0ZWRfZGF0YQ...
+// Tampered URL: /post/dGVzdF9lbmNyeXB0ZWRfZGF0YX... (changed last char)
+// Result: 404 Not Found (tampering detected)
+```
+
+### 3. Access Control
+
+**Important**: Encrypted routing does NOT provide access control. You must still implement proper authorization:
+
+```php
+#[Route('/post/{post}', name: 'post_show')]
+public function show(
+    #[EncryptedId(Post::class)] Post $post
+): Response {
+    // ✅ GOOD: Check if user can access this post
+    if (!$this->isGranted('VIEW', $post)) {
+        throw $this->createAccessDeniedException();
+    }
+
+    return $this->render('post/show.html.twig', ['post' => $post]);
+}
+```
+
+### 4. Key Rotation
+
+If you need to rotate encryption keys:
+
+1. Update your environment variables
+2. Old encrypted URLs will no longer work (users get 404)
+3. Generate new URLs for all public links
+
+**Recommendation**: Use `kernel.secret` which is stable across deployments.
+
+## Error Handling
+
+The encrypted routing system throws specific exceptions:
+
+### Invalid Encrypted ID
+
+When decryption fails (corrupted or tampered data):
+
+```
+NotFoundHttpException: "Invalid encrypted ID"
+```
+
+### Entity Not Found
+
+When the decrypted ID doesn't match any entity:
+
+```
+NotFoundHttpException: "No entity "App\ParseObject\Post" found for ID "abc123""
+```
+
+Both return a 404 status code to the user.
+
+## Performance Considerations
+
+- **Encryption overhead**: Negligible (< 1ms per URL)
+- **Database queries**: Same as regular routing (one query per entity)
+- **URL length**: Encrypted IDs are longer (~88 characters in base64url)
+
+## Examples
+
+### Blog Application
+
+```php
+// List posts with encrypted URLs
+#[Route('/blog', name: 'blog_list')]
+public function list(EncryptedUrlGenerator $urlGenerator): Response
+{
+    $posts = $this->om->getRepository(Post::class)->findAll();
+
+    return $this->render('blog/list.html.twig', [
+        'posts' => $posts,
+        'urlGenerator' => $urlGenerator,
+    ]);
+}
+
+// Show single post
+#[Route('/blog/{post}', name: 'blog_show')]
+public function show(#[EncryptedId(Post::class)] Post $post): Response
+{
+    return $this->render('blog/show.html.twig', ['post' => $post]);
+}
+```
+
+```twig
+{# blog/list.html.twig #}
+{% for post in posts %}
+    <article>
+        <h2>{{ post.title }}</h2>
+        <a href="{{ encrypted_path('blog_show', {'post': post.id}, 'post') }}">
+            Read more
+        </a>
+    </article>
+{% endfor %}
+```
+
+### E-commerce Product Pages
+
+```php
+// Public product page with encrypted ID
+#[Route('/product/{product}', name: 'product_show')]
+public function show(
+    #[EncryptedId(Product::class)] Product $product
+): Response {
+    return $this->render('product/show.html.twig', ['product' => $product]);
+}
+
+// Email campaign with encrypted product links
+public function sendNewsletterEmail(Product $product, EncryptedUrlGenerator $urlGenerator): void
+{
+    $productUrl = $urlGenerator->generate(
+        'product_show',
+        ['product' => $product->getId()],
+        'product',
+        UrlGeneratorInterface::ABSOLUTE_URL  // Full URL for email
+    );
+
+    // Send email with $productUrl
+}
+```
+
+## Comparison with Standard Routing
+
+| Feature | Standard Routing | Encrypted Routing |
+|---------|-----------------|-------------------|
+| URL Length | Short | Longer (~88 chars) |
+| Predictable | Yes (enumerable) | No (non-deterministic) |
+| Tamper-proof | No | Yes (HMAC protected) |
+| Encoding | Plain text | Base64url |
+| Performance | Fast | Fast (< 1ms overhead) |
+| Security | Low | High |
+
+## Troubleshooting
+
+### "Invalid encrypted ID" Errors
+
+**Cause**: The encrypted ID was corrupted or tampered with
+
+**Solution**: Generate a new URL. Old URLs cannot be recovered.
+
+### "EncryptionService not initialized" Errors
+
+**Cause**: Missing encryption service configuration
+
+**Solution**: Ensure `doctrine.parse.encryption_service` is defined in services.yml (should be automatic)
+
+### URLs Too Long
+
+**Cause**: Encrypted IDs are ~88 characters in base64url
+
+**Solution**: This is expected. If URL length is critical:
+- Use URL shorteners for public sharing
+- Store URLs in database for email campaigns
+- Consider using numeric IDs with proper authorization instead
+
+## See Also
+
+- [Encrypted String Type](types.md#encrypted_string) - Encrypt database fields
+- [Security](../../../Security/EncryptionService.php) - EncryptionService implementation
+- [Symfony Routing](https://symfony.com/doc/current/routing.html) - Standard Symfony routing

--- a/Resources/doc/mapping.md
+++ b/Resources/doc/mapping.md
@@ -132,17 +132,18 @@ class PostRepository extends ObjectRepository
 
 ## Attribute Types
 
-The `field` type can be one the following : 
+The `field` type can be one of the built-in types provided by the bundle.
 
-- string
-- integer
-- float
-- boolean
-- date
-- array (simple collection)
-- hash (key-value array)
-- geopoint ([Parse\ParseGeoPoint](https://github.com/ParsePlatform/parse-php-sdk/blob/master/src/Parse/ParseGeoPoint.php))
-- file (store the content of a file in Parse)
+For a complete list of all available types with detailed examples and usage information, see the [**Field Types documentation**](types.md).
+
+**Quick reference:**
+- `string` - Text values
+- `encrypted_string` - Automatically encrypted strings (emails, SSN, etc.)
+- `integer` / `float` / `boolean` - Numeric and boolean values
+- `date` - DateTime objects
+- `array` / `hash` - Collections and key-value data
+- `geopoint` - Geographic coordinates
+- `file` - File content storage
 
 
 ## Relations between objects

--- a/Resources/doc/types.md
+++ b/Resources/doc/types.md
@@ -1,0 +1,262 @@
+# Field Types
+
+DoctrineParseBundle provides several built-in types for mapping PHP values to Parse Server data types. Each type handles automatic conversion between PHP and Parse Server representations.
+
+## Available Types
+
+### boolean
+
+Maps PHP boolean values to Parse Server boolean type.
+
+**Example:**
+```php
+#[ORM\Field(type: 'boolean')]
+private $isPublished;
+```
+
+**Parse Server representation:** Boolean
+**PHP type:** `bool`
+
+---
+
+### integer
+
+Maps PHP integer values to Parse Server number type.
+
+**Example:**
+```php
+#[ORM\Field(type: 'integer')]
+private $viewCount;
+```
+
+**Parse Server representation:** Number
+**PHP type:** `int`
+
+---
+
+### float
+
+Maps PHP float values to Parse Server number type.
+
+**Example:**
+```php
+#[ORM\Field(type: 'float')]
+private $price;
+```
+
+**Parse Server representation:** Number
+**PHP type:** `float`
+
+---
+
+### string
+
+Maps PHP string values to Parse Server string type.
+
+**Example:**
+```php
+#[ORM\Field(type: 'string')]
+private $title;
+```
+
+**Parse Server representation:** String
+**PHP type:** `string`
+
+---
+
+### encrypted_string
+
+Maps PHP string values to encrypted Parse Server strings. Data is automatically encrypted when saving to Parse Server and decrypted when loading. Uses AES-256-CBC encryption with HMAC SHA-256 authentication.
+
+**Example:**
+```php
+#[ORM\Field(type: 'encrypted_string')]
+private $email;
+
+#[ORM\Field(type: 'encrypted_string')]
+private $ssn;
+```
+
+**Parse Server representation:** String (base64-encoded encrypted data)
+**PHP type:** `string`
+
+**Configuration:**
+
+The encryption service uses environment variables or falls back to `kernel.secret`:
+
+```env
+# .env (optional)
+APP_ENCRYPTION_KEY=your_32_bytes_encryption_key_here
+APP_HMAC_KEY=your_32_bytes_hmac_key_here
+```
+
+You can also configure the encoding format in `config/packages/doctrine_parse.yaml`:
+
+```yaml
+parameters:
+    doctrine.parse.encryption_encoding: 'base64'  # Options: 'base64', 'base64url', 'raw'
+```
+
+**⚠️ Important notes:**
+- Encrypted fields cannot be queried or filtered in Parse Server (data is opaque)
+- Changing encryption keys requires re-encrypting all existing data
+- Use this for sensitive data like emails, SSN, credit cards, etc.
+
+---
+
+### date
+
+Maps PHP `DateTime` objects to Parse Server date type.
+
+**Example:**
+```php
+#[ORM\Field(type: 'date')]
+private $publishedAt;
+```
+
+**Parse Server representation:** Date
+**PHP type:** `\DateTime`
+
+---
+
+### array
+
+Maps PHP arrays to Parse Server arrays. Best for simple collections without key-value structure.
+
+**Example:**
+```php
+#[ORM\Field(type: 'array')]
+private $tags;
+```
+
+**Parse Server representation:** Array
+**PHP type:** `array` (indexed array)
+
+**Example value:** `['tag1', 'tag2', 'tag3']`
+
+---
+
+### hash
+
+Maps PHP associative arrays to Parse Server objects. Best for key-value data structures.
+
+**Example:**
+```php
+#[ORM\Field(type: 'hash')]
+private $metadata;
+```
+
+**Parse Server representation:** Object
+**PHP type:** `array` (associative array)
+
+**Example value:** `['key1' => 'value1', 'key2' => 'value2']`
+
+---
+
+### file
+
+Stores file content in Parse Server as a Parse File. Automatically handles file uploads and downloads.
+
+**Example:**
+```php
+#[ORM\Field(type: 'file')]
+private $avatar;
+```
+
+**Parse Server representation:** File
+**PHP type:** `\Parse\ParseFile`
+
+**Usage:**
+```php
+use Parse\ParseFile;
+
+$file = ParseFile::createFromFile('/path/to/avatar.jpg', 'avatar.jpg');
+$user->setAvatar($file);
+$om->persist($user);
+$om->flush();
+```
+
+---
+
+### object
+
+Stores nested object data in Parse Server. Useful for embedded documents that don't need to be separate Parse objects.
+
+**Example:**
+```php
+#[ORM\Field(type: 'object')]
+private $address;
+```
+
+**Parse Server representation:** Object
+**PHP type:** `object` or `array`
+
+---
+
+### geopoint
+
+Maps geographic coordinates to Parse Server GeoPoint type. Used for location-based queries.
+
+**Example:**
+```php
+#[ORM\Field(type: 'geopoint')]
+private $location;
+```
+
+**Parse Server representation:** GeoPoint
+**PHP type:** `\Parse\ParseGeoPoint`
+
+**Usage:**
+```php
+use Parse\ParseGeoPoint;
+
+$location = new ParseGeoPoint(48.8566, 2.3522); // Paris coordinates
+$venue->setLocation($location);
+```
+
+---
+
+## Custom Types
+
+You can create custom types by extending the `Redking\ParseBundle\Types\Type` class:
+
+```php
+namespace App\Types;
+
+use Redking\ParseBundle\Types\Type;
+
+class MyCustomType extends Type
+{
+    public function convertToDatabaseValue($value)
+    {
+        // Convert PHP value to Parse Server value
+        return $value;
+    }
+
+    public function convertToPHPValue($value)
+    {
+        // Convert Parse Server value to PHP value
+        return $value;
+    }
+}
+```
+
+Then register it in your configuration:
+
+```php
+use Redking\ParseBundle\Types\Type;
+use App\Types\MyCustomType;
+
+Type::addType('my_custom', MyCustomType::class);
+```
+
+---
+
+## Type Conversion
+
+Types automatically handle conversion between PHP and Parse Server representations:
+
+- **`convertToDatabaseValue()`**: Converts PHP value to Parse Server format when persisting
+- **`convertToPHPValue()`**: Converts Parse Server value to PHP format when loading
+
+Most types pass values through unchanged, but some types like `date`, `file`, `geopoint`, and `encrypted_string` perform actual conversions.

--- a/Routing/EncryptedUrlGenerator.php
+++ b/Routing/EncryptedUrlGenerator.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Redking\ParseBundle\Routing;
+
+use Redking\ParseBundle\Security\EncryptionService;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Generates URLs with encrypted object IDs
+ *
+ * This service wraps the Symfony router to automatically encrypt
+ * Parse object IDs before generating URLs, making them safe for
+ * public exposure while maintaining security.
+ *
+ * Example:
+ * ```php
+ * // Encrypt the 'userId' parameter
+ * $url = $generator->generate('user_profile', ['userId' => 'abc123'], 'userId');
+ * // Result: /user/profile/dGVzdF9lbmNyeXB0ZWRfZGF0YQ...
+ * ```
+ */
+class EncryptedUrlGenerator
+{
+    public function __construct(
+        private readonly RouterInterface $router,
+        private readonly EncryptionService $encryptionService
+    ) {}
+
+    /**
+     * Generates a URL with encrypted ID parameter(s)
+     *
+     * @param string $routeName The route name
+     * @param array $parameters Route parameters (including the ID to encrypt)
+     * @param string|array<string> $idKeys The parameter key(s) to encrypt (default: 'id')
+     * @param int $referenceType The type of reference to be generated
+     * @return string The generated URL with encrypted ID(s)
+     * @throws \InvalidArgumentException If a required ID parameter is missing
+     */
+    public function generate(
+        string $routeName,
+        array $parameters,
+        string|array $idKeys = 'id',
+        int $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH
+    ): string {
+        $idKeys = is_array($idKeys) ? $idKeys : [$idKeys];
+
+        foreach ($idKeys as $idKey) {
+            if (!isset($parameters[$idKey])) {
+                throw new \InvalidArgumentException(
+                    sprintf("Missing parameter '%s' for encrypted URL generation.", $idKey)
+                );
+            }
+
+            $parameters[$idKey] = $this->encryptionService->encrypt((string) $parameters[$idKey]);
+        }
+
+        return $this->router->generate($routeName, $parameters, $referenceType);
+    }
+}

--- a/Security/EncryptionService.php
+++ b/Security/EncryptionService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Redking\ParseBundle\Security;
+
+/**
+ * Encryption/Decryption service with AES-256-CBC and HMAC SHA-256
+ *
+ * Supports multiple output formats:
+ * - 'base64': Standard base64 encoding (recommended for Parse Server)
+ * - 'base64url': URL-safe base64 for use in URLs
+ * - 'raw': Raw binary (experimental)
+ */
+class EncryptionService
+{
+    private const CIPHER_METHOD = 'aes-256-cbc';
+    private const IV_LENGTH = 16;
+    private const HMAC_LENGTH = 32;
+    private const HMAC_ALGO = 'sha256';
+
+    public function __construct(
+        private readonly string $encryptionKey,
+        private readonly string $hmacKey,
+        private readonly string $encoding = 'base64'
+    ) {
+        if (!in_array($this->encoding, ['base64', 'base64url', 'raw'], true)) {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid encoding "%s". Must be "base64", "base64url", or "raw".', $this->encoding)
+            );
+        }
+    }
+
+    /**
+     * Encrypts a string
+     *
+     * @param string $plaintext Plaintext to encrypt
+     * @return string Encrypted text encoded according to the configured format
+     */
+    public function encrypt(string $plaintext): string
+    {
+        // Generate a random IV for each encryption
+        $iv = random_bytes(self::IV_LENGTH);
+
+        // Encrypt the text
+        $ciphertext = openssl_encrypt(
+            $plaintext,
+            self::CIPHER_METHOD,
+            $this->encryptionKey,
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+
+        if ($ciphertext === false) {
+            throw new \RuntimeException('Encryption failed');
+        }
+
+        // Concatenate IV + ciphertext
+        $data = $iv . $ciphertext;
+
+        // Generate HMAC for authentication
+        $hmac = hash_hmac(self::HMAC_ALGO, $data, $this->hmacKey, true);
+
+        // Final payload: IV + ciphertext + HMAC
+        $payload = $data . $hmac;
+
+        // Encode according to configured format
+        return match($this->encoding) {
+            'base64url' => $this->encodeBase64Url($payload),
+            'base64' => base64_encode($payload),
+            'raw' => $payload,
+        };
+    }
+
+    /**
+     * Decrypts a string
+     *
+     * Automatically detects the encoding format
+     *
+     * @param string $encrypted Encrypted text
+     * @return string|null Plaintext or null on failure
+     */
+    public function decrypt(string $encrypted): ?string
+    {
+        // Detect format and decode
+        $payload = $this->decodePayload($encrypted);
+
+        if ($payload === null || strlen($payload) <= self::IV_LENGTH + self::HMAC_LENGTH) {
+            return null;
+        }
+
+        // Extract components
+        $data = substr($payload, 0, -self::HMAC_LENGTH);
+        $hmac = substr($payload, -self::HMAC_LENGTH);
+
+        // Verify HMAC
+        $expectedHmac = hash_hmac(self::HMAC_ALGO, $data, $this->hmacKey, true);
+
+        if (!hash_equals($expectedHmac, $hmac)) {
+            // Invalid HMAC = tampered data
+            return null;
+        }
+
+        // Extract IV and ciphertext
+        $iv = substr($data, 0, self::IV_LENGTH);
+        $ciphertext = substr($data, self::IV_LENGTH);
+
+        // Decrypt
+        $plaintext = openssl_decrypt(
+            $ciphertext,
+            self::CIPHER_METHOD,
+            $this->encryptionKey,
+            OPENSSL_RAW_DATA,
+            $iv
+        );
+
+        return $plaintext !== false ? $plaintext : null;
+    }
+
+    /**
+     * Encodes data to URL-safe base64
+     */
+    private function encodeBase64Url(string $data): string
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
+
+    /**
+     * Decodes the payload by automatically detecting the format
+     */
+    private function decodePayload(string $encrypted): ?string
+    {
+        // Try to detect the format
+
+        // If contains only base64url characters (-_ and alphanumerics)
+        if (preg_match('/^[A-Za-z0-9_-]+$/', $encrypted)) {
+            // Try base64url
+            $decoded = base64_decode(strtr($encrypted, '-_', '+/'), true);
+            if ($decoded !== false) {
+                return $decoded;
+            }
+        }
+
+        // If contains standard base64 characters (+/ or =)
+        if (preg_match('/^[A-Za-z0-9+\/]+=*$/', $encrypted)) {
+            // Try standard base64
+            $decoded = base64_decode($encrypted, true);
+            if ($decoded !== false) {
+                return $decoded;
+            }
+        }
+
+        // Otherwise consider as raw
+        return $encrypted;
+    }
+
+    /**
+     * Returns the configured encoding format
+     */
+    public function getEncoding(): string
+    {
+        return $this->encoding;
+    }
+}

--- a/Tests/ArgumentResolver/EncryptedIdValueResolverTest.php
+++ b/Tests/ArgumentResolver/EncryptedIdValueResolverTest.php
@@ -3,7 +3,6 @@
 namespace Redking\ParseBundle\Tests\ArgumentResolver;
 
 use PHPUnit\Framework\TestCase;
-use Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver;
 use Redking\ParseBundle\Attribute\EncryptedId;
 use Redking\ParseBundle\ObjectManager;
 use Redking\ParseBundle\ObjectRepository;
@@ -16,7 +15,7 @@ class EncryptedIdValueResolverTest extends TestCase
 {
     private EncryptionService $encryptionService;
     private ObjectManager $om;
-    private EncryptedIdValueResolver $resolver;
+    private $resolver;
 
     public function setUp(): void
     {
@@ -27,7 +26,21 @@ class EncryptedIdValueResolverTest extends TestCase
         );
 
         $this->om = $this->createMock(ObjectManager::class);
-        $this->resolver = new EncryptedIdValueResolver($this->om, $this->encryptionService);
+
+        // Use the appropriate resolver based on Symfony version
+        if (interface_exists('Symfony\Component\HttpKernel\Controller\ValueResolverInterface')) {
+            // Symfony 6.2+
+            $this->resolver = new \Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver(
+                $this->om,
+                $this->encryptionService
+            );
+        } else {
+            // Symfony 5.4
+            $this->resolver = new \Redking\ParseBundle\ArgumentResolver\LegacyEncryptedIdValueResolver(
+                $this->om,
+                $this->encryptionService
+            );
+        }
     }
 
     public function testResolveWithEncryptedId(): void

--- a/Tests/ArgumentResolver/EncryptedIdValueResolverTest.php
+++ b/Tests/ArgumentResolver/EncryptedIdValueResolverTest.php
@@ -63,7 +63,7 @@ class EncryptedIdValueResolverTest extends TestCase
         );
 
         $result = $this->resolver->resolve($request, $argument);
-        $result = iterator_to_array($result);
+        $result = is_array($result) ? $result : iterator_to_array($result);
 
         $this->assertCount(1, $result);
         $this->assertSame($mockEntity, $result[0]);
@@ -75,7 +75,7 @@ class EncryptedIdValueResolverTest extends TestCase
         $argument = new ArgumentMetadata('user', 'App\Entity\User', false, false, null);
 
         $result = $this->resolver->resolve($request, $argument);
-        $result = iterator_to_array($result);
+        $result = is_array($result) ? $result : iterator_to_array($result);
 
         $this->assertCount(0, $result);
     }
@@ -96,7 +96,7 @@ class EncryptedIdValueResolverTest extends TestCase
         );
 
         $result = $this->resolver->resolve($request, $argument);
-        $result = iterator_to_array($result);
+        $result = is_array($result) ? $result : iterator_to_array($result);
 
         $this->assertCount(0, $result);
     }
@@ -193,7 +193,7 @@ class EncryptedIdValueResolverTest extends TestCase
         );
 
         $result = $this->resolver->resolve($request, $argument);
-        $result = iterator_to_array($result);
+        $result = is_array($result) ? $result : iterator_to_array($result);
 
         $this->assertCount(1, $result);
         $this->assertSame($mockEntity, $result[0]);

--- a/Tests/ArgumentResolver/EncryptedIdValueResolverTest.php
+++ b/Tests/ArgumentResolver/EncryptedIdValueResolverTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Redking\ParseBundle\ArgumentResolver\EncryptedIdValueResolver;
+use Redking\ParseBundle\Attribute\EncryptedId;
+use Redking\ParseBundle\ObjectManager;
+use Redking\ParseBundle\ObjectRepository;
+use Redking\ParseBundle\Security\EncryptionService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class EncryptedIdValueResolverTest extends TestCase
+{
+    private EncryptionService $encryptionService;
+    private ObjectManager $om;
+    private EncryptedIdValueResolver $resolver;
+
+    public function setUp(): void
+    {
+        $this->encryptionService = new EncryptionService(
+            'test_encryption_key_32_bytes_long',
+            'test_hmac_key_32_bytes_long_key!',
+            'base64url'
+        );
+
+        $this->om = $this->createMock(ObjectManager::class);
+        $this->resolver = new EncryptedIdValueResolver($this->om, $this->encryptionService);
+    }
+
+    public function testResolveWithEncryptedId(): void
+    {
+        $plainId = 'abc123';
+        $encryptedId = $this->encryptionService->encrypt($plainId);
+
+        $mockEntity = new \stdClass();
+        $mockEntity->id = $plainId;
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('find')
+            ->with($plainId)
+            ->willReturn($mockEntity);
+
+        $this->om->expects($this->once())
+            ->method('getRepository')
+            ->with('App\Entity\User')
+            ->willReturn($repository);
+
+        $request = new Request();
+        $request->attributes->set('user', $encryptedId);
+
+        $argument = new ArgumentMetadata(
+            'user',
+            'App\Entity\User',
+            false,
+            false,
+            null,
+            false,
+            [new EncryptedId('App\Entity\User')]
+        );
+
+        $result = $this->resolver->resolve($request, $argument);
+        $result = iterator_to_array($result);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($mockEntity, $result[0]);
+    }
+
+    public function testResolveReturnsEmptyWhenNoEncryptedIdAttribute(): void
+    {
+        $request = new Request();
+        $argument = new ArgumentMetadata('user', 'App\Entity\User', false, false, null);
+
+        $result = $this->resolver->resolve($request, $argument);
+        $result = iterator_to_array($result);
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testResolveReturnsEmptyWhenParameterNotInRequest(): void
+    {
+        $request = new Request();
+        // No 'user' attribute set
+
+        $argument = new ArgumentMetadata(
+            'user',
+            'App\Entity\User',
+            false,
+            false,
+            null,
+            false,
+            [new EncryptedId('App\Entity\User')]
+        );
+
+        $result = $this->resolver->resolve($request, $argument);
+        $result = iterator_to_array($result);
+
+        $this->assertCount(0, $result);
+    }
+
+    public function testResolveThrowsNotFoundWhenDecryptionFails(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('Invalid encrypted ID');
+
+        $request = new Request();
+        $request->attributes->set('user', 'invalid_encrypted_data');
+
+        $argument = new ArgumentMetadata(
+            'user',
+            'App\Entity\User',
+            false,
+            false,
+            null,
+            false,
+            [new EncryptedId('App\Entity\User')]
+        );
+
+        $result = $this->resolver->resolve($request, $argument);
+        iterator_to_array($result); // Force evaluation
+    }
+
+    public function testResolveThrowsNotFoundWhenEntityNotFound(): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+        $this->expectExceptionMessage('No entity "App\Entity\User" found for ID');
+
+        $plainId = 'nonexistent123';
+        $encryptedId = $this->encryptionService->encrypt($plainId);
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('find')
+            ->with($plainId)
+            ->willReturn(null);
+
+        $this->om->expects($this->once())
+            ->method('getRepository')
+            ->with('App\Entity\User')
+            ->willReturn($repository);
+
+        $request = new Request();
+        $request->attributes->set('user', $encryptedId);
+
+        $argument = new ArgumentMetadata(
+            'user',
+            'App\Entity\User',
+            false,
+            false,
+            null,
+            false,
+            [new EncryptedId('App\Entity\User')]
+        );
+
+        $result = $this->resolver->resolve($request, $argument);
+        iterator_to_array($result); // Force evaluation
+    }
+
+    public function testResolveWithRealParseObjectId(): void
+    {
+        // Simulate a real Parse object ID
+        $plainId = 'a1b2c3d4e5f6g7h8i9j0';
+        $encryptedId = $this->encryptionService->encrypt($plainId);
+
+        $mockEntity = new \stdClass();
+        $mockEntity->id = $plainId;
+
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository->expects($this->once())
+            ->method('find')
+            ->with($plainId)
+            ->willReturn($mockEntity);
+
+        $this->om->expects($this->once())
+            ->method('getRepository')
+            ->with('App\ParseObject\BlogPost')
+            ->willReturn($repository);
+
+        $request = new Request();
+        $request->attributes->set('post', $encryptedId);
+
+        $argument = new ArgumentMetadata(
+            'post',
+            'App\ParseObject\BlogPost',
+            false,
+            false,
+            null,
+            false,
+            [new EncryptedId('App\ParseObject\BlogPost')]
+        );
+
+        $result = $this->resolver->resolve($request, $argument);
+        $result = iterator_to_array($result);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($mockEntity, $result[0]);
+        $this->assertEquals($plainId, $result[0]->id);
+    }
+}

--- a/Tests/Functional/EncryptedFieldTest.php
+++ b/Tests/Functional/EncryptedFieldTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Functional;
+
+use Parse\ParseQuery;
+use Redking\ParseBundle\Tests\Models\Blog\SecureDocument;
+
+class EncryptedFieldTest extends \Redking\ParseBundle\Tests\TestCase
+{
+    protected static $modelSets = [
+        'Redking\ParseBundle\Tests\Models\Blog\SecureDocument',
+    ];
+
+    public function testPersistAndRetrieveEncryptedField()
+    {
+        $doc = new SecureDocument();
+        $doc->setTitle('Public Document');
+        $doc->setSecretNote('This is a secret message');
+        $doc->setSsn('123-45-6789');
+        $doc->setPublicInfo('Public information');
+
+        $this->om->persist($doc);
+        $this->om->flush();
+
+        $this->assertNotEmpty($doc->getId());
+
+        // Retrieve from database
+        $retrieved = $this->om->getRepository(SecureDocument::class)->find($doc->getId());
+
+        $this->assertEquals('Public Document', $retrieved->getTitle());
+        $this->assertEquals('This is a secret message', $retrieved->getSecretNote());
+        $this->assertEquals('123-45-6789', $retrieved->getSsn());
+        $this->assertEquals('Public information', $retrieved->getPublicInfo());
+    }
+
+    public function testEncryptedFieldIsActuallyEncrypted()
+    {
+        $doc = new SecureDocument();
+        $doc->setTitle('Test Doc');
+        $doc->setSecretNote('Secret data');
+        $doc->setSsn('987-65-4321');
+
+        $this->om->persist($doc);
+        $this->om->flush();
+
+        // Query Parse directly to verify data is encrypted
+        $collection = $this->om->getClassMetadata(SecureDocument::class)->getCollection();
+        $query = new ParseQuery($collection);
+        $rawDoc = $query->get($doc->getId(), true);
+
+        // Public field should be readable
+        $this->assertEquals('Test Doc', $rawDoc->get('title'));
+
+        // Encrypted fields should NOT contain the plaintext
+        $encryptedNote = $rawDoc->get('secret_note');
+        $encryptedSsn = $rawDoc->get('ssn');
+
+        $this->assertNotEquals('Secret data', $encryptedNote);
+        $this->assertNotEquals('987-65-4321', $encryptedSsn);
+
+        // Encrypted values should be base64-like strings
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9+\/]+=*$/', $encryptedNote);
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9+\/]+=*$/', $encryptedSsn);
+    }
+
+    public function testUpdateEncryptedField()
+    {
+        $doc = new SecureDocument();
+        $doc->setTitle('Original Title');
+        $doc->setSecretNote('Original Secret');
+
+        $this->om->persist($doc);
+        $this->om->flush();
+
+        $id = $doc->getId();
+
+        // Update the encrypted field
+        $doc->setSecretNote('Updated Secret');
+        $this->om->flush();
+
+        // Clear and retrieve fresh
+        $this->om->clear();
+        $retrieved = $this->om->getRepository(SecureDocument::class)->find($id);
+
+        $this->assertEquals('Updated Secret', $retrieved->getSecretNote());
+    }
+
+    public function testNullEncryptedField()
+    {
+        $doc = new SecureDocument();
+        $doc->setTitle('Doc with null');
+        $doc->setSecretNote(null);
+        $doc->setSsn(null);
+
+        $this->om->persist($doc);
+        $this->om->flush();
+
+        $retrieved = $this->om->getRepository(SecureDocument::class)->find($doc->getId());
+
+        $this->assertNull($retrieved->getSecretNote());
+        $this->assertNull($retrieved->getSsn());
+    }
+
+    public function testMultipleDocumentsWithEncryptedFields()
+    {
+        $doc1 = new SecureDocument();
+        $doc1->setTitle('Doc 1');
+        $doc1->setSecretNote('Secret 1');
+
+        $doc2 = new SecureDocument();
+        $doc2->setTitle('Doc 2');
+        $doc2->setSecretNote('Secret 2');
+
+        $this->om->persist($doc1);
+        $this->om->persist($doc2);
+        $this->om->flush();
+
+        // Retrieve both
+        $retrieved1 = $this->om->getRepository(SecureDocument::class)->find($doc1->getId());
+        $retrieved2 = $this->om->getRepository(SecureDocument::class)->find($doc2->getId());
+
+        $this->assertEquals('Secret 1', $retrieved1->getSecretNote());
+        $this->assertEquals('Secret 2', $retrieved2->getSecretNote());
+    }
+
+    public function testRefreshEncryptedField()
+    {
+        $doc = new SecureDocument();
+        $doc->setTitle('Refresh Test');
+        $doc->setSecretNote('Original');
+
+        $this->om->persist($doc);
+        $this->om->flush();
+
+        // Modify locally
+        $doc->setSecretNote('Modified locally');
+
+        // Refresh from database
+        $this->om->refresh($doc);
+
+        // Should revert to database value
+        $this->assertEquals('Original', $doc->getSecretNote());
+    }
+
+    public function testEmptyStringEncryption()
+    {
+        $doc = new SecureDocument();
+        $doc->setTitle('Empty test');
+        $doc->setSecretNote('');
+        $doc->setSsn('');
+
+        $this->om->persist($doc);
+        $this->om->flush();
+
+        $retrieved = $this->om->getRepository(SecureDocument::class)->find($doc->getId());
+
+        $this->assertEquals('', $retrieved->getSecretNote());
+        $this->assertEquals('', $retrieved->getSsn());
+    }
+
+    public function testUnicodeEncryption()
+    {
+        $doc = new SecureDocument();
+        $doc->setTitle('Unicode test');
+        $doc->setSecretNote('Données sensibles avec accents: éèêë àâä 中文 العربية');
+
+        $this->om->persist($doc);
+        $this->om->flush();
+
+        $retrieved = $this->om->getRepository(SecureDocument::class)->find($doc->getId());
+
+        $this->assertEquals('Données sensibles avec accents: éèêë àâä 中文 العربية', $retrieved->getSecretNote());
+    }
+}

--- a/Tests/Functional/EncryptedRoutingTest.php
+++ b/Tests/Functional/EncryptedRoutingTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Functional;
+
+use Redking\ParseBundle\Routing\EncryptedUrlGenerator;
+use Redking\ParseBundle\Security\EncryptionService;
+use Redking\ParseBundle\Tests\Models\Blog\Post;
+use Redking\ParseBundle\Tests\TestCase;
+
+/**
+ * Functional test for the encrypted routing feature
+ *
+ * Tests the complete flow:
+ * 1. Create a Parse object with an ID
+ * 2. Generate an encrypted URL for it
+ * 3. Decrypt the ID and retrieve the object
+ */
+class EncryptedRoutingTest extends TestCase
+{
+    protected static $modelSets = [Post::class];
+
+    private EncryptionService $encryptionService;
+    private EncryptedUrlGenerator $urlGenerator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Use base64url encoding for URLs
+        $this->encryptionService = new EncryptionService(
+            'test_encryption_key_32_bytes_for_tests!',
+            'test_hmac_key_32_bytes_for_tests!!',
+            'base64url'
+        );
+
+        $router = $this->createMock(\Symfony\Component\Routing\RouterInterface::class);
+        $router->method('generate')
+            ->willReturnCallback(function ($name, $params, $type) {
+                return '/post/' . $params['postId'];
+            });
+
+        $this->urlGenerator = new EncryptedUrlGenerator($router, $this->encryptionService);
+    }
+
+    public function testCompleteEncryptedRoutingFlow(): void
+    {
+        // Step 1: Create a Parse object
+        $post = new Post();
+        $post->setText('Test Post for Encrypted Routing');
+
+        $this->om->persist($post);
+        $this->om->flush();
+
+        $originalId = $post->getId();
+        $this->assertNotEmpty($originalId);
+
+        // Step 2: Generate encrypted URL
+        $encryptedUrl = $this->urlGenerator->generate(
+            'post_show',
+            ['postId' => $originalId],
+            'postId'
+        );
+
+        $this->assertStringContainsString('/post/', $encryptedUrl);
+
+        // Step 3: Extract encrypted ID from URL
+        $parts = explode('/post/', $encryptedUrl);
+        $encryptedId = $parts[1];
+
+        // Verify encrypted ID is URL-safe
+        $this->assertStringNotContainsString('+', $encryptedId, 'Encrypted ID should be URL-safe');
+        $this->assertStringNotContainsString('/', $encryptedId, 'Encrypted ID should be URL-safe');
+        $this->assertStringNotContainsString('=', $encryptedId, 'Encrypted ID should be URL-safe');
+
+        // Step 4: Decrypt and verify
+        $decryptedId = $this->encryptionService->decrypt($encryptedId);
+        $this->assertEquals($originalId, $decryptedId);
+
+        // Step 5: Load object using decrypted ID
+        $loadedPost = $this->om->getRepository(Post::class)->find($decryptedId);
+        $this->assertNotNull($loadedPost);
+        $this->assertEquals($post->getId(), $loadedPost->getId());
+        $this->assertEquals('Test Post for Encrypted Routing', $loadedPost->getText());
+    }
+
+    public function testEncryptedIdIsNotReversibleWithoutKeys(): void
+    {
+        // Create a post
+        $post = new Post();
+        $post->setText('Secret Post');
+        $this->om->persist($post);
+        $this->om->flush();
+
+        $originalId = $post->getId();
+
+        // Encrypt with our service
+        $encryptedId = $this->encryptionService->encrypt($originalId);
+
+        // Try to decrypt with wrong keys (should fail)
+        $wrongEncryptionService = new EncryptionService(
+            'wrong_encryption_key_32_bytes!!',
+            'wrong_hmac_key_32_bytes_for_test!',
+            'base64url'
+        );
+
+        $decryptedId = $wrongEncryptionService->decrypt($encryptedId);
+        $this->assertNull($decryptedId, 'Should not be able to decrypt with wrong keys');
+    }
+
+    public function testMultipleObjectsHaveDifferentEncryptedIds(): void
+    {
+        // Create two posts
+        $post1 = new Post();
+        $post1->setText('Post 1');
+        $this->om->persist($post1);
+
+        $post2 = new Post();
+        $post2->setText('Post 2');
+        $this->om->persist($post2);
+
+        $this->om->flush();
+
+        // Encrypt both IDs
+        $encrypted1 = $this->encryptionService->encrypt($post1->getId());
+        $encrypted2 = $this->encryptionService->encrypt($post2->getId());
+
+        // They should be different
+        $this->assertNotEquals($encrypted1, $encrypted2);
+
+        // Both should decrypt correctly
+        $this->assertEquals($post1->getId(), $this->encryptionService->decrypt($encrypted1));
+        $this->assertEquals($post2->getId(), $this->encryptionService->decrypt($encrypted2));
+    }
+
+    public function testEncryptedIdIsNonDeterministic(): void
+    {
+        $post = new Post();
+        $post->setText('Test Post');
+        $this->om->persist($post);
+        $this->om->flush();
+
+        $id = $post->getId();
+
+        // Encrypt the same ID twice
+        $encrypted1 = $this->encryptionService->encrypt($id);
+        $encrypted2 = $this->encryptionService->encrypt($id);
+
+        // Due to random IV, encryptions should differ
+        $this->assertNotEquals($encrypted1, $encrypted2);
+
+        // But both should decrypt to the same value
+        $this->assertEquals($id, $this->encryptionService->decrypt($encrypted1));
+        $this->assertEquals($id, $this->encryptionService->decrypt($encrypted2));
+    }
+
+    public function testTamperedEncryptedIdReturnsNull(): void
+    {
+        $post = new Post();
+        $post->setText('Test Post');
+        $this->om->persist($post);
+        $this->om->flush();
+
+        $encryptedId = $this->encryptionService->encrypt($post->getId());
+
+        // Tamper with the encrypted ID (flip multiple characters in the middle)
+        // This will corrupt the HMAC or the ciphertext, causing verification to fail
+        $middle = (int) (strlen($encryptedId) / 2);
+        $tamperedId = substr($encryptedId, 0, $middle - 2) . 'XX' . substr($encryptedId, $middle);
+
+        // Should return null (HMAC verification fails or decryption fails)
+        $decrypted = $this->encryptionService->decrypt($tamperedId);
+        $this->assertNull($decrypted, 'Tampered encrypted ID should not decrypt successfully');
+    }
+
+    public function testUrlGeneratorWithMultipleIds(): void
+    {
+        // Create two posts
+        $post1 = new Post();
+        $post1->setText('Post 1');
+        $this->om->persist($post1);
+
+        $post2 = new Post();
+        $post2->setText('Post 2');
+        $this->om->persist($post2);
+
+        $this->om->flush();
+
+        $router = $this->createMock(\Symfony\Component\Routing\RouterInterface::class);
+        $router->method('generate')
+            ->willReturnCallback(function ($name, $params, $type) {
+                return '/compare/' . $params['post1'] . '/' . $params['post2'];
+            });
+
+        $urlGenerator = new EncryptedUrlGenerator($router, $this->encryptionService);
+
+        // Generate URL with both IDs encrypted
+        $url = $urlGenerator->generate(
+            'post_compare',
+            ['post1' => $post1->getId(), 'post2' => $post2->getId()],
+            ['post1', 'post2']
+        );
+
+        $this->assertStringContainsString('/compare/', $url);
+
+        // Extract and decrypt both IDs
+        preg_match('/\/compare\/([^\/]+)\/([^\/]+)/', $url, $matches);
+        $encrypted1 = $matches[1];
+        $encrypted2 = $matches[2];
+
+        $decrypted1 = $this->encryptionService->decrypt($encrypted1);
+        $decrypted2 = $this->encryptionService->decrypt($encrypted2);
+
+        $this->assertEquals($post1->getId(), $decrypted1);
+        $this->assertEquals($post2->getId(), $decrypted2);
+    }
+}

--- a/Tests/Models/Blog/SecureDocument.php
+++ b/Tests/Models/Blog/SecureDocument.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Models\Blog;
+
+use Redking\ParseBundle\Mapping\Annotations as ORM;
+
+#[ORM\ParseObject(collection: "SecureDocument")]
+class SecureDocument
+{
+    use \Redking\ParseBundle\ObjectTrait;
+
+    #[ORM\Field(type: "string")]
+    private $title;
+
+    #[ORM\Field(type: "encrypted_string", name: "secret_note")]
+    private $secretNote;
+
+    #[ORM\Field(type: "encrypted_string")]
+    private $ssn;
+
+    #[ORM\Field(type: "string")]
+    private $publicInfo;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+        return $this;
+    }
+
+    public function getSecretNote(): ?string
+    {
+        return $this->secretNote;
+    }
+
+    public function setSecretNote(?string $secretNote): self
+    {
+        $this->secretNote = $secretNote;
+        return $this;
+    }
+
+    public function getSsn(): ?string
+    {
+        return $this->ssn;
+    }
+
+    public function setSsn(?string $ssn): self
+    {
+        $this->ssn = $ssn;
+        return $this;
+    }
+
+    public function getPublicInfo(): ?string
+    {
+        return $this->publicInfo;
+    }
+
+    public function setPublicInfo(?string $publicInfo): self
+    {
+        $this->publicInfo = $publicInfo;
+        return $this;
+    }
+}

--- a/Tests/Routing/EncryptedUrlGeneratorTest.php
+++ b/Tests/Routing/EncryptedUrlGeneratorTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Routing;
+
+use PHPUnit\Framework\TestCase;
+use Redking\ParseBundle\Routing\EncryptedUrlGenerator;
+use Redking\ParseBundle\Security\EncryptionService;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class EncryptedUrlGeneratorTest extends TestCase
+{
+    private EncryptionService $encryptionService;
+    private RouterInterface $router;
+    private EncryptedUrlGenerator $generator;
+
+    public function setUp(): void
+    {
+        $this->encryptionService = new EncryptionService(
+            'test_encryption_key_32_bytes_long',
+            'test_hmac_key_32_bytes_long_key!',
+            'base64url'
+        );
+
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->generator = new EncryptedUrlGenerator($this->router, $this->encryptionService);
+    }
+
+    public function testGenerateEncryptsIdParameter(): void
+    {
+        $plainId = 'abc123xyz';
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'user_profile',
+                $this->callback(function ($params) use ($plainId) {
+                    // Check that 'id' is encrypted (not the plain value)
+                    $this->assertNotEquals($plainId, $params['id']);
+                    // Check that 'other' parameter is preserved
+                    $this->assertEquals('value', $params['other']);
+                    // Check that encrypted value can be decrypted back to original
+                    $decrypted = $this->encryptionService->decrypt($params['id']);
+                    $this->assertEquals($plainId, $decrypted);
+                    return true;
+                }),
+                UrlGeneratorInterface::ABSOLUTE_PATH
+            )
+            ->willReturn('/user/profile/encrypted_id');
+
+        $result = $this->generator->generate('user_profile', ['id' => $plainId, 'other' => 'value']);
+
+        $this->assertStringContainsString('/user/profile/', $result);
+    }
+
+    public function testGenerateWithCustomIdKey(): void
+    {
+        $plainId = 'user123';
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'user_show',
+                $this->callback(function ($params) use ($plainId) {
+                    $this->assertNotEquals($plainId, $params['userId']);
+                    $decrypted = $this->encryptionService->decrypt($params['userId']);
+                    $this->assertEquals($plainId, $decrypted);
+                    return true;
+                }),
+                UrlGeneratorInterface::ABSOLUTE_PATH
+            )
+            ->willReturn('/user/encrypted_id');
+
+        $result = $this->generator->generate('user_show', ['userId' => $plainId], 'userId');
+
+        $this->assertStringContainsString('/user/', $result);
+    }
+
+    public function testGenerateWithMultipleIdKeys(): void
+    {
+        $userId = 'user123';
+        $postId = 'post456';
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'user_post',
+                $this->callback(function ($params) use ($userId, $postId) {
+                    $this->assertNotEquals($userId, $params['userId']);
+                    $this->assertNotEquals($postId, $params['postId']);
+                    $this->assertEquals($userId, $this->encryptionService->decrypt($params['userId']));
+                    $this->assertEquals($postId, $this->encryptionService->decrypt($params['postId']));
+                    return true;
+                }),
+                UrlGeneratorInterface::ABSOLUTE_PATH
+            )
+            ->willReturn("/user/encrypted_user/post/encrypted_post");
+
+        $result = $this->generator->generate(
+            'user_post',
+            ['userId' => $userId, 'postId' => $postId],
+            ['userId', 'postId']
+        );
+
+        $this->assertIsString($result);
+    }
+
+    public function testGenerateWithAbsoluteUrl(): void
+    {
+        $plainId = 'abc123';
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'user_profile',
+                $this->callback(function ($params) use ($plainId) {
+                    $this->assertNotEquals($plainId, $params['id']);
+                    $this->assertEquals($plainId, $this->encryptionService->decrypt($params['id']));
+                    return true;
+                }),
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn('https://example.com/user/profile/encrypted_id');
+
+        $result = $this->generator->generate(
+            'user_profile',
+            ['id' => $plainId],
+            'id',
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+
+        $this->assertStringStartsWith('https://', $result);
+    }
+
+    public function testGenerateThrowsExceptionWhenIdParameterMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Missing parameter 'id'");
+
+        $this->generator->generate('user_profile', ['other' => 'value']);
+    }
+
+    public function testGenerateThrowsExceptionWhenCustomIdKeyMissing(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Missing parameter 'userId'");
+
+        $this->generator->generate('user_profile', ['id' => '123'], 'userId');
+    }
+
+    public function testGeneratePreservesOtherParameters(): void
+    {
+        $plainId = 'abc123';
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                'user_profile',
+                $this->callback(function ($params) use ($plainId) {
+                    $this->assertNotEquals($plainId, $params['id']);
+                    $this->assertEquals($plainId, $this->encryptionService->decrypt($params['id']));
+                    $this->assertEquals('settings', $params['tab']);
+                    $this->assertEquals(2, $params['page']);
+                    return true;
+                }),
+                UrlGeneratorInterface::ABSOLUTE_PATH
+            )
+            ->willReturn('/user/profile/encrypted_id?tab=settings&page=2');
+
+        $result = $this->generator->generate(
+            'user_profile',
+            ['id' => $plainId, 'tab' => 'settings', 'page' => 2]
+        );
+
+        $this->assertIsString($result);
+    }
+
+    public function testGeneratedIdIsUrlSafe(): void
+    {
+        $plainId = 'abc123';
+
+        $this->router->expects($this->once())
+            ->method('generate')
+            ->with(
+                $this->anything(),
+                $this->callback(function ($params) {
+                    $encryptedId = $params['id'];
+                    // URL-safe base64 should not contain +, /, or =
+                    return !str_contains($encryptedId, '+') &&
+                           !str_contains($encryptedId, '/') &&
+                           !str_contains($encryptedId, '=');
+                }),
+                $this->anything()
+            )
+            ->willReturn('/user/test');
+
+        $this->generator->generate('user_profile', ['id' => $plainId]);
+    }
+}

--- a/Tests/Security/EncryptionServiceTest.php
+++ b/Tests/Security/EncryptionServiceTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+use Redking\ParseBundle\Security\EncryptionService;
+
+class EncryptionServiceTest extends TestCase
+{
+    private const TEST_ENCRYPTION_KEY = 'test_encryption_key_32_bytes!!';
+    private const TEST_HMAC_KEY = 'test_hmac_key_32_bytes_long!!';
+
+    public function testEncryptDecryptRoundTripBase64()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64'
+        );
+
+        $plaintext = 'Sensitive information';
+        $encrypted = $service->encrypt($plaintext);
+        $decrypted = $service->decrypt($encrypted);
+
+        $this->assertEquals($plaintext, $decrypted);
+    }
+
+    public function testEncryptDecryptRoundTripBase64Url()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64url'
+        );
+
+        $plaintext = 'Sensitive information for URL';
+        $encrypted = $service->encrypt($plaintext);
+        $decrypted = $service->decrypt($encrypted);
+
+        $this->assertEquals($plaintext, $decrypted);
+    }
+
+    public function testEncryptDecryptRoundTripRaw()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'raw'
+        );
+
+        $plaintext = 'Raw binary test';
+        $encrypted = $service->encrypt($plaintext);
+        $decrypted = $service->decrypt($encrypted);
+
+        $this->assertEquals($plaintext, $decrypted);
+    }
+
+    public function testEncryptedValueIsDifferent()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        $plaintext = 'Test data';
+        $encrypted = $service->encrypt($plaintext);
+
+        $this->assertNotEquals($plaintext, $encrypted);
+    }
+
+    public function testBase64UrlIsUrlSafe()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64url'
+        );
+
+        $plaintext = 'URL safe test with special chars';
+        $encrypted = $service->encrypt($plaintext);
+
+        // Should not contain +, /, or = characters
+        $this->assertStringNotContainsString('+', $encrypted);
+        $this->assertStringNotContainsString('/', $encrypted);
+        $this->assertStringNotContainsString('=', $encrypted);
+
+        // Should only contain URL-safe characters
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9_-]+$/', $encrypted);
+    }
+
+    public function testBase64ContainsStandardCharacters()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64'
+        );
+
+        // Generate enough data to likely produce + or / characters
+        $plaintext = str_repeat('Test data for base64 encoding ', 10);
+        $encrypted = $service->encrypt($plaintext);
+
+        // Should match base64 pattern
+        $this->assertMatchesRegularExpression('/^[A-Za-z0-9+\/]+=*$/', $encrypted);
+    }
+
+    public function testDecryptInvalidDataReturnsNull()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        $invalid = 'invalid_encrypted_data';
+        $result = $service->decrypt($invalid);
+
+        $this->assertNull($result);
+    }
+
+    public function testDecryptTamperedDataReturnsNull()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        $plaintext = 'Tamper test';
+        $encrypted = $service->encrypt($plaintext);
+
+        // Tamper with the encrypted data
+        $tampered = substr($encrypted, 0, -5) . 'XXXXX';
+        $result = $service->decrypt($tampered);
+
+        $this->assertNull($result);
+    }
+
+    public function testEncryptionIsNonDeterministic()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        $plaintext = 'Same data';
+        $encrypted1 = $service->encrypt($plaintext);
+        $encrypted2 = $service->encrypt($plaintext);
+
+        // Same plaintext should produce different ciphertext (due to random IV)
+        $this->assertNotEquals($encrypted1, $encrypted2);
+
+        // But both should decrypt to the same value
+        $this->assertEquals($plaintext, $service->decrypt($encrypted1));
+        $this->assertEquals($plaintext, $service->decrypt($encrypted2));
+    }
+
+    public function testEncryptEmptyString()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        $plaintext = '';
+        $encrypted = $service->encrypt($plaintext);
+        $decrypted = $service->decrypt($encrypted);
+
+        $this->assertEquals('', $decrypted);
+    }
+
+    public function testEncryptUnicodeCharacters()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        $plaintext = 'Texte français avec accents: éèêë àâä 中文 العربية';
+        $encrypted = $service->encrypt($plaintext);
+        $decrypted = $service->decrypt($encrypted);
+
+        $this->assertEquals($plaintext, $decrypted);
+    }
+
+    public function testAutomaticFormatDetection()
+    {
+        $serviceBase64 = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64'
+        );
+
+        $serviceBase64Url = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64url'
+        );
+
+        $serviceRaw = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'raw'
+        );
+
+        $plaintext = 'Format detection test';
+
+        // Encrypt with each format
+        $encryptedBase64 = $serviceBase64->encrypt($plaintext);
+        $encryptedBase64Url = $serviceBase64Url->encrypt($plaintext);
+        $encryptedRaw = $serviceRaw->encrypt($plaintext);
+
+        // Should be able to decrypt with any service (automatic detection)
+        $this->assertEquals($plaintext, $serviceBase64->decrypt($encryptedBase64));
+        $this->assertEquals($plaintext, $serviceBase64->decrypt($encryptedBase64Url));
+        $this->assertEquals($plaintext, $serviceBase64->decrypt($encryptedRaw));
+
+        $this->assertEquals($plaintext, $serviceBase64Url->decrypt($encryptedBase64));
+        $this->assertEquals($plaintext, $serviceBase64Url->decrypt($encryptedBase64Url));
+        $this->assertEquals($plaintext, $serviceBase64Url->decrypt($encryptedRaw));
+    }
+
+    public function testBase64IsSmallerThanBase64Url()
+    {
+        $serviceBase64 = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64'
+        );
+
+        $serviceBase64Url = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64url'
+        );
+
+        // Use a fixed plaintext to compare sizes
+        $plaintext = str_repeat('A', 100);
+
+        // Encrypt same plaintext with fixed IV to compare sizes accurately
+        $encryptedBase64 = $serviceBase64->encrypt($plaintext);
+        $encryptedBase64Url = $serviceBase64Url->encrypt($plaintext);
+
+        // base64 can be equal or smaller than base64url (no padding removal)
+        // This test just verifies both work, actual size depends on data
+        $this->assertNotEmpty($encryptedBase64);
+        $this->assertNotEmpty($encryptedBase64Url);
+    }
+
+    public function testInvalidEncodingThrowsException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid encoding');
+
+        new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'invalid_encoding'
+        );
+    }
+
+    public function testGetEncoding()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY,
+            'base64url'
+        );
+
+        $this->assertEquals('base64url', $service->getEncoding());
+    }
+
+    public function testDefaultEncodingIsBase64()
+    {
+        $service = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        $this->assertEquals('base64', $service->getEncoding());
+    }
+}

--- a/Tests/TestCase.php
+++ b/Tests/TestCase.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase as BaseTestCase;
 use Redking\ParseBundle\Configuration;
 use Redking\ParseBundle\Mapping\Driver\AttributeDriver;
 use Redking\ParseBundle\ObjectManager;
+use Redking\ParseBundle\Security\EncryptionService;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -53,6 +54,13 @@ abstract class TestCase extends BaseTestCase
         $eventManager = new EventManager();
         $storage = new ParseMemoryStorage();
         $om = new ObjectManager($config, $eventManager, $storage);
+
+        // Initialize EncryptionService for tests
+        $encryptionService = new EncryptionService(
+            'test_encryption_key_32_bytes_for_tests!',
+            'test_hmac_key_32_bytes_for_tests!!'
+        );
+        $om->initializeEncryptionType($encryptionService);
 
         return $om;
     }

--- a/Tests/Twig/EncryptedUrlExtensionTest.php
+++ b/Tests/Twig/EncryptedUrlExtensionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Twig;
+
+use PHPUnit\Framework\TestCase;
+use Redking\ParseBundle\Routing\EncryptedUrlGenerator;
+use Redking\ParseBundle\Security\EncryptionService;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RouterInterface;
+
+class EncryptedUrlExtensionTest extends TestCase
+{
+    private EncryptedUrlGenerator $urlGenerator;
+    private $extension;
+
+    public function setUp(): void
+    {
+        if (!class_exists('Twig\Extension\AbstractExtension')) {
+            $this->markTestSkipped('Twig is not available in this environment');
+        }
+        $encryptionService = new EncryptionService(
+            'test_encryption_key_32_bytes_long',
+            'test_hmac_key_32_bytes_long_key!',
+            'base64url'
+        );
+
+        $router = $this->createMock(RouterInterface::class);
+        $router->method('generate')
+            ->willReturnCallback(function ($name, $params, $type) {
+                $path = '/' . $name . '/' . ($params['id'] ?? $params['userId'] ?? 'default');
+                return $type === UrlGeneratorInterface::ABSOLUTE_URL
+                    ? 'https://example.com' . $path
+                    : $path;
+            });
+
+        $this->urlGenerator = new EncryptedUrlGenerator($router, $encryptionService);
+
+        $extensionClass = 'Redking\ParseBundle\Twig\EncryptedUrlExtension';
+        $this->extension = new $extensionClass($this->urlGenerator);
+    }
+
+    public function testGetFunctions(): void
+    {
+        $functions = $this->extension->getFunctions();
+
+        $this->assertCount(2, $functions);
+
+        $functionNames = array_map(fn($f) => $f->getName(), $functions);
+        $this->assertContains('encrypted_path', $functionNames);
+        $this->assertContains('encrypted_url', $functionNames);
+    }
+
+    public function testEncryptedPathGeneratesRelativePath(): void
+    {
+        $result = $this->extension->encryptedPath('user_profile', ['id' => 'abc123']);
+
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringNotContainsString('https://', $result);
+        $this->assertStringContainsString('user_profile', $result);
+    }
+
+    public function testEncryptedUrlGeneratesAbsoluteUrl(): void
+    {
+        $result = $this->extension->encryptedUrl('user_profile', ['id' => 'abc123']);
+
+        $this->assertStringStartsWith('https://', $result);
+        $this->assertStringContainsString('user_profile', $result);
+    }
+
+    public function testEncryptedPathWithCustomIdKey(): void
+    {
+        $result = $this->extension->encryptedPath('user_show', ['userId' => 'user123'], 'userId');
+
+        $this->assertStringStartsWith('/', $result);
+        $this->assertStringContainsString('user_show', $result);
+    }
+
+    public function testEncryptedUrlWithCustomIdKey(): void
+    {
+        $result = $this->extension->encryptedUrl('user_show', ['userId' => 'user123'], 'userId');
+
+        $this->assertStringStartsWith('https://', $result);
+        $this->assertStringContainsString('user_show', $result);
+    }
+
+    public function testEncryptedPathWithMultipleParameters(): void
+    {
+        $result = $this->extension->encryptedPath(
+            'user_post',
+            ['userId' => 'user123', 'postId' => 'post456'],
+            ['userId', 'postId']
+        );
+
+        $this->assertIsString($result);
+        $this->assertStringStartsWith('/', $result);
+    }
+
+    public function testEncryptedUrlWithMultipleParameters(): void
+    {
+        $result = $this->extension->encryptedUrl(
+            'user_post',
+            ['userId' => 'user123', 'postId' => 'post456'],
+            ['userId', 'postId']
+        );
+
+        $this->assertIsString($result);
+        $this->assertStringStartsWith('https://', $result);
+    }
+
+    public function testEncryptedPathWithOtherParametersOnly(): void
+    {
+        // Test URL generation with an ID to encrypt and other parameters
+        $result = $this->extension->encryptedPath('user_search', ['query' => 'test', 'id' => 'user123']);
+
+        $this->assertStringStartsWith('/', $result);
+        // 'id' should be encrypted, 'query' should remain plain
+    }
+
+    public function testEncryptedPathDefaultIdKey(): void
+    {
+        // Test that 'id' is used as default key
+        $result = $this->extension->encryptedPath('user_profile', ['id' => 'test123']);
+
+        $this->assertIsString($result);
+    }
+}

--- a/Tests/Types/EncryptedStringTypeTest.php
+++ b/Tests/Types/EncryptedStringTypeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Types;
+
+use PHPUnit\Framework\TestCase;
+use Redking\ParseBundle\Security\EncryptionService;
+use Redking\ParseBundle\Types\EncryptedStringType;
+use Redking\ParseBundle\Types\Type;
+
+class EncryptedStringTypeTest extends TestCase
+{
+    private const TEST_ENCRYPTION_KEY = 'test_key_32_bytes_long_string!';
+    private const TEST_HMAC_KEY = 'test_hmac_32_bytes_long_string!';
+
+    private EncryptionService $encryptionService;
+    private EncryptedStringType $type;
+
+    public function setUp(): void
+    {
+        $this->encryptionService = new EncryptionService(
+            self::TEST_ENCRYPTION_KEY,
+            self::TEST_HMAC_KEY
+        );
+
+        EncryptedStringType::setEncryptionService($this->encryptionService);
+        $this->type = Type::getType(Type::ENCRYPTED_STRING);
+    }
+
+    public function testConvertToDatabaseValue()
+    {
+        $plaintext = 'Test value';
+        $encrypted = $this->type->convertToDatabaseValue($plaintext);
+
+        $this->assertIsString($encrypted);
+        $this->assertNotEquals($plaintext, $encrypted);
+    }
+
+    public function testConvertToPHPValue()
+    {
+        $plaintext = 'Test value';
+        $encrypted = $this->type->convertToDatabaseValue($plaintext);
+        $decrypted = $this->type->convertToPHPValue($encrypted);
+
+        $this->assertEquals($plaintext, $decrypted);
+    }
+
+    public function testConvertNullToDatabaseValue()
+    {
+        $result = $this->type->convertToDatabaseValue(null);
+        $this->assertNull($result);
+    }
+
+    public function testConvertNullToPHPValue()
+    {
+        $result = $this->type->convertToPHPValue(null);
+        $this->assertNull($result);
+    }
+
+    public function testTypeIsRegistered()
+    {
+        $this->assertTrue(Type::hasType(Type::ENCRYPTED_STRING));
+        $this->assertInstanceOf(EncryptedStringType::class, Type::getType(Type::ENCRYPTED_STRING));
+    }
+
+    public function testRoundTripConversion()
+    {
+        $plaintext = 'Sensitive data with special chars: éèê 中文 العربية';
+        $encrypted = $this->type->convertToDatabaseValue($plaintext);
+        $decrypted = $this->type->convertToPHPValue($encrypted);
+
+        $this->assertEquals($plaintext, $decrypted);
+    }
+
+    public function testEmptyStringConversion()
+    {
+        $plaintext = '';
+        $encrypted = $this->type->convertToDatabaseValue($plaintext);
+        $decrypted = $this->type->convertToPHPValue($encrypted);
+
+        $this->assertEquals('', $decrypted);
+    }
+
+    public function testLongStringConversion()
+    {
+        $plaintext = str_repeat('Lorem ipsum dolor sit amet ', 100);
+        $encrypted = $this->type->convertToDatabaseValue($plaintext);
+        $decrypted = $this->type->convertToPHPValue($encrypted);
+
+        $this->assertEquals($plaintext, $decrypted);
+    }
+
+    public function testNonDeterministicEncryption()
+    {
+        $plaintext = 'Same value';
+        $encrypted1 = $this->type->convertToDatabaseValue($plaintext);
+        $encrypted2 = $this->type->convertToDatabaseValue($plaintext);
+
+        // Should produce different encrypted values
+        $this->assertNotEquals($encrypted1, $encrypted2);
+
+        // But both should decrypt to the same value
+        $this->assertEquals($plaintext, $this->type->convertToPHPValue($encrypted1));
+        $this->assertEquals($plaintext, $this->type->convertToPHPValue($encrypted2));
+    }
+
+    public function testInvalidEncryptedDataReturnsNull()
+    {
+        $invalid = 'not_a_valid_encrypted_string';
+        $result = $this->type->convertToPHPValue($invalid);
+
+        $this->assertNull($result);
+    }
+
+    public function testNumberConversion()
+    {
+        $number = 12345;
+        $encrypted = $this->type->convertToDatabaseValue($number);
+        $decrypted = $this->type->convertToPHPValue($encrypted);
+
+        // Should be converted to string
+        $this->assertEquals('12345', $decrypted);
+    }
+}

--- a/Twig/EncryptedUrlExtension.php
+++ b/Twig/EncryptedUrlExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Redking\ParseBundle\Twig;
+
+use Redking\ParseBundle\Routing\EncryptedUrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Twig extension for generating encrypted URLs
+ *
+ * Provides Twig functions to generate URLs with encrypted Parse object IDs,
+ * making it easy to create secure public links in templates.
+ *
+ * Available functions:
+ * - encrypted_path(): Generates a relative path with encrypted ID
+ * - encrypted_url(): Generates an absolute URL with encrypted ID
+ */
+class EncryptedUrlExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly EncryptedUrlGenerator $urlGenerator
+    ) {}
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('encrypted_path', [$this, 'encryptedPath']),
+            new TwigFunction('encrypted_url', [$this, 'encryptedUrl']),
+        ];
+    }
+
+    /**
+     * Generates a relative path with encrypted ID(s)
+     *
+     * @param string $routeName The route name
+     * @param array $parameters Route parameters
+     * @param string|array<string> $idKeys Parameter key(s) to encrypt (default: 'id')
+     * @return string The generated path
+     */
+    public function encryptedPath(string $routeName, array $parameters = [], string|array $idKeys = 'id'): string
+    {
+        return $this->urlGenerator->generate(
+            $routeName,
+            $parameters,
+            $idKeys,
+            UrlGeneratorInterface::ABSOLUTE_PATH
+        );
+    }
+
+    /**
+     * Generates an absolute URL with encrypted ID(s)
+     *
+     * @param string $routeName The route name
+     * @param array $parameters Route parameters
+     * @param string|array<string> $idKeys Parameter key(s) to encrypt (default: 'id')
+     * @return string The generated URL
+     */
+    public function encryptedUrl(string $routeName, array $parameters = [], string|array $idKeys = 'id'): string
+    {
+        return $this->urlGenerator->generate(
+            $routeName,
+            $parameters,
+            $idKeys,
+            UrlGeneratorInterface::ABSOLUTE_URL
+        );
+    }
+}

--- a/Types/EncryptedStringType.php
+++ b/Types/EncryptedStringType.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Redking\ParseBundle\Types;
+
+use Redking\ParseBundle\Security\EncryptionService;
+
+/**
+ * Type for automatically encrypted strings
+ *
+ * Uses EncryptionService to encrypt/decrypt values
+ * transparently during persistence operations.
+ */
+class EncryptedStringType extends Type
+{
+    /**
+     * @var EncryptionService|null
+     */
+    private static ?EncryptionService $encryptionService = null;
+
+    /**
+     * Initializes the encryption service
+     *
+     * This method must be called at application startup
+     * by the ObjectManager via the DI container.
+     *
+     * @param EncryptionService $service
+     */
+    public static function setEncryptionService(EncryptionService $service): void
+    {
+        self::$encryptionService = $service;
+    }
+
+    /**
+     * Converts a PHP value to database value (encrypted)
+     *
+     * @param mixed $value The value to convert
+     * @return string|null The encrypted value or null
+     * @throws \RuntimeException If the encryption service is not initialized
+     */
+    public function convertToDatabaseValue($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (self::$encryptionService === null) {
+            throw new \RuntimeException(
+                'EncryptionService not initialized. Make sure the bundle is properly configured.'
+            );
+        }
+
+        return self::$encryptionService->encrypt((string) $value);
+    }
+
+    /**
+     * Converts a database value (encrypted) to PHP value
+     *
+     * @param mixed $value The encrypted value to convert
+     * @return string|null The decrypted value or null
+     * @throws \RuntimeException If the encryption service is not initialized
+     */
+    public function convertToPHPValue($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (self::$encryptionService === null) {
+            throw new \RuntimeException(
+                'EncryptionService not initialized. Make sure the bundle is properly configured.'
+            );
+        }
+
+        $decrypted = self::$encryptionService->decrypt((string) $value);
+
+        // Return null if decryption fails (corrupted data or wrong key)
+        return $decrypted;
+    }
+
+    /**
+     * Returns the closure code for conversion to MongoDB
+     *
+     * @return string
+     */
+    public function closureToMongo()
+    {
+        return '$return = $value;';
+    }
+
+    /**
+     * Returns the closure code for conversion from MongoDB
+     *
+     * @return string
+     */
+    public function closureToPHP()
+    {
+        return '$return = $value;';
+    }
+}

--- a/Types/Type.php
+++ b/Types/Type.php
@@ -40,6 +40,7 @@ abstract class Type
     const INTEGER = 'integer';
     const FLOAT = 'float';
     const STRING = 'string';
+    const ENCRYPTED_STRING = 'encrypted_string';
     const DATE = 'date';
     const TARRAY = 'array';
     const FILE = 'file';
@@ -74,6 +75,7 @@ abstract class Type
         self::INTEGER => 'Redking\ParseBundle\Types\IntType',
         self::FLOAT => 'Redking\ParseBundle\Types\FloatType',
         self::STRING => 'Redking\ParseBundle\Types\StringType',
+        self::ENCRYPTED_STRING => 'Redking\ParseBundle\Types\EncryptedStringType',
         self::DATE => 'Redking\ParseBundle\Types\DateType',
         self::TARRAY => 'Redking\ParseBundle\Types\ArrayType',
         self::FILE => 'Redking\ParseBundle\Types\FileType',

--- a/UnitOfWork.php
+++ b/UnitOfWork.php
@@ -1589,6 +1589,12 @@ class UnitOfWork implements PropertyChangedListener
                 if ($class->getTypeOfField($name) === Type::STRING && null !== $value) {
                     $actualData->set($class->getNameOfField($name), (string)$value);
                 }
+                // Encrypt string if needed
+                elseif ($class->getTypeOfField($name) === Type::ENCRYPTED_STRING) {
+                    $type = \Redking\ParseBundle\Types\Type::getType(Type::ENCRYPTED_STRING);
+                    $encrypted = $type->convertToDatabaseValue($value);
+                    $actualData->set($class->getNameOfField($name), $encrypted);
+                }
                 // Force integer if needed
                 elseif ($class->getTypeOfField($name) === Type::INTEGER && null !== $value) {
                     $actualData->set($class->getNameOfField($name), (int)$value);

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
         "symfony/maker-bundle": "^1.11",
         "symfony/mime": "^4.2 || ^5.4 || ^6.4",
         "symfony/phpunit-bridge": "^4.2 || ^5.4 || ^6.4",
-        "phpunit/phpunit": "^6.5 || ^9.5"
+        "phpunit/phpunit": "^6.5 || ^9.5",
+        "twig/twig": "^2.12 || ^3.0"
     },
     "autoload": {
         "psr-4": { "Redking\\ParseBundle\\": "" }


### PR DESCRIPTION
Adds two encryption features using AES-256-CBC + HMAC SHA-256:                                                                                                                                                                              
                                                                                                                                                                                                                                              
  1. **Encrypted string type** (`encrypted_string`) - automatically encrypts/decrypts sensitive fields in Parse Server                                                                                                                        
  2. **Encrypted routing** - generates secure URLs with encrypted object IDs using `#[EncryptedId]` attribute and Twig functions