### PR TITLE
fix: make var-exporter proxies implement Doctrine\Persistence\Proxy

### DIFF
--- a/src/Proxy/ProxyFactory.php
+++ b/src/Proxy/ProxyFactory.php
@@ -272,8 +272,54 @@ final class ProxyFactory
         $proxyShortName = substr($proxyClassName, strrpos($proxyClassName, '\\') + 1);
 
         $ghostBody = ProxyHelper::generateLazyGhost(new ReflectionClass($className));
+        $ghostBody = self::injectDoctrinePersistenceProxy($ghostBody);
 
         return sprintf("namespace %s;\n\nclass %s%s", $proxyNamespace, $proxyShortName, $ghostBody);
+    }
+
+    /**
+     * Adapts the var-exporter ghost body so the generated class also implements
+     * \Doctrine\Persistence\Proxy. The Symfony Bridge ManagerRegistry uses this
+     * interface as the marker to strip the proxy prefix in getManagerForClass().
+     *
+     * Also exposes setLazyObjectAsInitialized() as the public __setInitialized()
+     * method expected by Doctrine\Persistence\Reflection\RuntimeReflectionProperty,
+     * which otherwise silently no-ops when writing to a Proxy whose
+     * __isInitialized() returns false.
+     */
+    private static function injectDoctrinePersistenceProxy(string $ghostBody): string
+    {
+        $withInterface = str_replace(
+            'implements \Symfony\Component\VarExporter\LazyObjectInterface',
+            'implements \Symfony\Component\VarExporter\LazyObjectInterface, \Doctrine\Persistence\Proxy',
+            $ghostBody,
+        );
+
+        $withTraitAlias = str_replace(
+            'use \Symfony\Component\VarExporter\LazyGhostTrait;',
+            "use \Symfony\Component\VarExporter\LazyGhostTrait {\n"
+                . "        setLazyObjectAsInitialized as public __setInitialized;\n"
+                . '    }',
+            $withInterface,
+        );
+
+        $stubs = <<<'PHP'
+
+    public function __load(): void
+    {
+        $this->initializeLazyObject();
+    }
+
+    public function __isInitialized(): bool
+    {
+        return isset($this->lazyObjectState) && $this->isLazyObjectInitialized();
+    }
+
+PHP;
+
+        // Insert the stubs just before the closing brace of the class body
+        // (which is followed by a blank line and the opcache.preload hints).
+        return str_replace("}\n\n// Help opcache.preload", $stubs . "}\n\n// Help opcache.preload", $withTraitAlias);
     }
 
     /**

--- a/tests/Functional/RegistryProxyTest.php
+++ b/tests/Functional/RegistryProxyTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Functional;
+
+use Doctrine\Persistence\Proxy as DoctrinePersistenceProxy;
+use Redking\ParseBundle\Configuration;
+use Redking\ParseBundle\ObjectManager;
+use Redking\ParseBundle\Registry;
+use Redking\ParseBundle\Tests\Models\Blog\Invoice;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * Reproduces the downstream bundle bug where Registry::getManagerForClass()
+ * was called with a generated proxy class name and returned null because the
+ * proxy did not implement Doctrine\Persistence\Proxy (the marker the
+ * AbstractManagerRegistry uses to strip the proxy prefix).
+ */
+class RegistryProxyTest extends \Redking\ParseBundle\Tests\TestCase
+{
+    protected static $modelSets = [
+        Invoice::class,
+    ];
+
+    public function testGetManagerForClassResolvesProxyClass(): void
+    {
+        $container = new Container();
+        $container->set('redking_parse.manager', $this->om);
+
+        $registry = new Registry($container, 'redking_parse.manager');
+
+        $invoice = new Invoice();
+        $invoice->setReference('REGISTRY-PROXY-001');
+        $this->om->persist($invoice);
+        $this->om->flush();
+
+        $id = $invoice->getId();
+        $this->om->clear();
+
+        $reference  = $this->om->getReference(Invoice::class, $id);
+        $proxyClass = get_class($reference);
+
+        $manager = $registry->getManagerForClass($proxyClass);
+
+        $this->assertInstanceOf(
+            ObjectManager::class,
+            $manager,
+            sprintf('Registry must resolve the manager for proxy class %s', $proxyClass)
+        );
+    }
+
+    public function testVarExporterProxyImplementsDoctrinePersistenceProxy(): void
+    {
+        if ($this->om->getConfiguration()->isLazyGhostObjectEnabled()) {
+            $this->markTestSkipped('Native lazy ghosts re-use the entity class itself — no marker interface needed.');
+        }
+
+        $invoice = new Invoice();
+        $invoice->setReference('REGISTRY-PROXY-002');
+        $this->om->persist($invoice);
+        $this->om->flush();
+
+        $id = $invoice->getId();
+        $this->om->clear();
+
+        $reference = $this->om->getReference(Invoice::class, $id);
+
+        $this->assertNotSame(
+            Invoice::class,
+            get_class($reference),
+            'Var-exporter mode must generate a distinct proxy class.'
+        );
+
+        $this->assertInstanceOf(
+            DoctrinePersistenceProxy::class,
+            $reference,
+            'Generated proxies must implement Doctrine\\Persistence\\Proxy so the Symfony Bridge ManagerRegistry can strip the proxy prefix.'
+        );
+    }
+}


### PR DESCRIPTION
The Symfony Bridge AbstractManagerRegistry::getManagerForClass() uses Doctrine\Persistence\Proxy as the marker interface to strip the proxy class prefix and walk up to the real entity class. Our var-exporter ghosts only implemented LazyObjectInterface, so calls such as $registry->getManagerForClass(get_class($proxy)) returned null and downstream bundles failed with "No document manager defined for class ParseProxies\__CG__\...".

Generated proxies now also implement Doctrine\Persistence\Proxy and expose:
- __load(): forwards to initializeLazyObject();
- __isInitialized(): reflects the lazy object state;
- __setInitialized(bool): aliased from LazyGhostTrait's private setLazyObjectAsInitialized() — required by Doctrine\Persistence\Reflection\RuntimeReflectionProperty, which silently no-ops when writing to a Proxy whose __isInitialized() returns false and that lacks __setInitialized().

Native PHP 8.4 lazy ghosts re-use the entity class itself and need no adjustment.

Adds tests/Functional/RegistryProxyTest covering both paths.