### PR TITLE
fix(hydrator): make multi-include queries return concrete entities

### DIFF
--- a/src/Hydrator/ParseObjectHydrator.php
+++ b/src/Hydrator/ParseObjectHydrator.php
@@ -84,6 +84,48 @@ class ParseObjectHydrator
             }
         }
 
+        // Pre-register normal-class instances for every association whose payload
+        // is fully available, BEFORE recursing into nested hydration. Without this,
+        // a Pointer field encountered first during a sibling include's recursive
+        // hydration calls getReference() and locks a generated proxy class into the
+        // identity map; the top-level full payload that arrives next then only
+        // re-hydrates the proxy in place, leaving the user with a __CG__\... proxy
+        // class for the second include even though the data is fully loaded.
+        $uow = $this->om->getUnitOfWork();
+        foreach ($this->class->associationMappings as $assoc) {
+            $targetClass = $this->om->getClassMetadata($assoc['targetDocument']);
+            $rootName    = $targetClass->rootEntityName;
+
+            if ($assoc['type'] === ClassMetadata::ONE) {
+                $ref = $data->get($assoc['name']);
+                if ($ref instanceof ParseObject && $ref->isDataAvailable()) {
+                    $refId = $ref->getObjectId();
+                    if ($refId !== null && $uow->tryGetById($refId, $rootName) === false) {
+                        $uow->registerManaged($targetClass->newInstance(), $refId, $ref);
+                    }
+                }
+                continue;
+            }
+
+            try {
+                $refs = $data->get($assoc['name']);
+            } catch (\Exception $e) {
+                continue;
+            }
+            if (!is_array($refs)) {
+                continue;
+            }
+            foreach ($refs as $ref) {
+                if (!$ref instanceof ParseObject || !$ref->isDataAvailable()) {
+                    continue;
+                }
+                $refId = $ref->getObjectId();
+                if ($refId !== null && $uow->tryGetById($refId, $rootName) === false) {
+                    $uow->registerManaged($targetClass->newInstance(), $refId, $ref);
+                }
+            }
+        }
+
         // load associations
         foreach ($this->class->associationMappings as $field => $assoc) {
             $targetClass = $this->om->getClassMetadata($assoc['targetDocument']);

--- a/src/UnitOfWork.php
+++ b/src/UnitOfWork.php
@@ -531,17 +531,31 @@ class UnitOfWork implements PropertyChangedListener
             $oid = spl_object_hash($object);
 
             if ($this->om->isUninitializedObject($object)) {
-                // Mark the lazy ghost as initialized without firing its initializer:
+                // Mark the lazy ghost as initialized BEFORE the hydrator runs:
                 // we already have fresh $data and the hydrator below will populate every
-                // reflected property. On PHP 8.4 the native API exposes a dedicated method;
-                // for symfony/var-exporter ghosts the per-property writes done by the
-                // hydrator are enough to flip the LazyObjectState.
+                // reflected property. Without this, the proxy ends up populated but still
+                // flagged UNINITIALIZED_FULL, so any later property access (or any __set
+                // dispatched from a class method that writes a private parent/trait
+                // property — e.g. ACLTrait::setPublicAcl()) trips the initializer and
+                // emits a redundant Parse query.
+                //
+                // Two backends are handled here:
+                //  - PHP 8.4 native lazy ghosts (ReflectionClass::newLazyGhost), via
+                //    ReflectionClass::markLazyObjectAsInitialized().
+                //  - symfony/var-exporter ghosts (default), via the public
+                //    __setInitialized alias added by
+                //    Proxy/ProxyFactory::injectDoctrinePersistenceProxy(), which is the
+                //    LazyGhostTrait::setLazyObjectAsInitialized() method.
                 if (PHP_VERSION_ID >= 80400) {
                     $reflClass = $class->getReflectionClass();
                     if (method_exists($reflClass, 'markLazyObjectAsInitialized')
                         && $reflClass->isUninitializedLazyObject($object)) {
                         $reflClass->markLazyObjectAsInitialized($object);
                     }
+                }
+                if ($object instanceof \Symfony\Component\VarExporter\LazyObjectInterface
+                    && method_exists($object, '__setInitialized')) {
+                    $object->__setInitialized(true);
                 }
                 $overrideLocalValues = true;
             } else {

--- a/tests/Functional/IncludeKeyHydrationTest.php
+++ b/tests/Functional/IncludeKeyHydrationTest.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Functional;
+
+use Redking\ParseBundle\Tests\Models\Blog\ChainNode;
+use Redking\ParseBundle\Tests\Models\Blog\Post;
+use Redking\ParseBundle\Tests\Models\Blog\User;
+
+/**
+ * Regression tests for the multi-includeKey bug: when a Parse query carries
+ * several top-level include clauses, the Hydrator processes nested Pointer
+ * fields before the matching top-level included payload, which leaves a lazy
+ * proxy in the identity map. The proxy is then re-hydrated by
+ * UnitOfWork::getOrCreateObject(), but Doctrine\Persistence\Reflection
+ * \RuntimeReflectionProperty::setValue() flips the VarExporter LazyObjectState
+ * back to UNINITIALIZED_FULL after each write — so the proxy ends up populated
+ * yet still flagged as lazy, and any later property access triggers a
+ * redundant Parse query.
+ */
+class IncludeKeyHydrationTest extends \Redking\ParseBundle\Tests\TestCase
+{
+    protected static $modelSets = [
+        User::class,
+        Post::class,
+        ChainNode::class,
+    ];
+
+    /**
+     * Scenario A — re-hydration of a pre-existing proxy through includeKey().
+     *
+     * Place a User proxy in the identity map up-front (this mirrors what
+     * happens when a nested Pointer in a sibling included object is processed
+     * first), then run a Post query with includeKey('user'). The included
+     * payload must mark the existing proxy as initialized; touching it must
+     * not emit any extra query.
+     */
+    public function testIncludeKeyRehydratesPreExistingProxy(): void
+    {
+        $user = new User();
+        $user->setName('Alice');
+        $user->setPassword('p');
+        $this->om->persist($user);
+
+        $post = new Post();
+        $post->setText('hello');
+        $post->setUser($user);
+        $this->om->persist($post);
+
+        $this->om->flush();
+        $postId = $post->getId();
+        $userId = $user->getId();
+        $this->om->clear();
+
+        $userProxy = $this->om->getReference(User::class, $userId);
+        $this->assertTrue(
+            $this->om->isUninitializedObject($userProxy),
+            'getReference must return an uninitialized proxy'
+        );
+
+        $queries = [];
+        $this->om->getConfiguration()->setLoggerCallable(
+            static function (array $q) use (&$queries) { $queries[] = $q; }
+        );
+
+        $loadedPost = $this->om->createQueryBuilder(Post::class)
+            ->field('id')->equals($postId)
+            ->includeKey('user')
+            ->getQuery()
+            ->getSingleResult();
+
+        $this->assertNotNull($loadedPost);
+        $this->assertCount(1, $queries, 'Only the Post query should fire');
+
+        $this->assertFalse(
+            $this->om->isUninitializedObject($userProxy),
+            'The included payload must mark the existing proxy as initialized'
+        );
+
+        $this->assertSame('Alice', $loadedPost->getUser()->getName());
+        $this->assertCount(
+            1,
+            $queries,
+            'Reading after include-driven re-hydration must not query'
+        );
+    }
+
+    /**
+     * A direct query that returns a payload for an entity already represented
+     * by a proxy in the identity map must hydrate the proxy in place. The
+     * proxy must be flipped to INITIALIZED after the query so that later
+     * property accesses do not trigger the lazy initializer.
+     */
+    public function testQueryRehydratesPreExistingProxy(): void
+    {
+        $user = new User();
+        $user->setName('Bob');
+        $user->setPassword('p');
+        $this->om->persist($user);
+        $this->om->flush();
+
+        $userId = $user->getId();
+        $this->om->clear();
+
+        $userProxy = $this->om->getReference(User::class, $userId);
+        $this->assertTrue($this->om->isUninitializedObject($userProxy));
+
+        $queries = [];
+        $this->om->getConfiguration()->setLoggerCallable(
+            static function (array $q) use (&$queries) { $queries[] = $q; }
+        );
+
+        $loaded = $this->om->createQueryBuilder(User::class)
+            ->field('id')->equals($userId)
+            ->getQuery()
+            ->getSingleResult();
+
+        $this->assertSame($userProxy, $loaded, 'The proxy must be returned in place');
+        $this->assertCount(1, $queries, 'Only the User query should fire');
+        $this->assertFalse(
+            $this->om->isUninitializedObject($userProxy),
+            'The query payload must mark the existing proxy as initialized'
+        );
+
+        $this->assertSame('Bob', $loaded->getName());
+        $this->assertCount(1, $queries, 'Reading after re-hydration must not query');
+    }
+
+    /**
+     * Reproduces the user-reported "mixed proxy / non-proxy" symptom across
+     * multiple top-level includes. The graph is:
+     *
+     *     root --first--> A --first--> B
+     *     root --second--> B
+     *
+     * When root is queried with includeKey('first').includeKey('second'),
+     * Parse Server fully embeds A inside root.first and B inside root.second.
+     * During hydration, A's nested A.first Pointer to B is encountered before
+     * the top-level root.second payload — without the fix, that nested
+     * Pointer creates a generated proxy for B which then survives as the
+     * identity-map entry, so root.second ends up as the proxy class while
+     * root.first stays the original class.
+     *
+     * After the fix, both included relations must be instances of the
+     * original entity class, and the nested A.first must reference the very
+     * same B as root.second (identity preserved).
+     */
+    public function testMultipleIncludesAllHydrateToOriginalClass(): void
+    {
+        $b = new ChainNode();
+        $b->setLabel('B');
+        $this->om->persist($b);
+
+        $a = new ChainNode();
+        $a->setLabel('A');
+        $a->setFirst($b);
+        $this->om->persist($a);
+
+        $root = new ChainNode();
+        $root->setLabel('root');
+        $root->setFirst($a);
+        $root->setSecond($b);
+        $this->om->persist($root);
+
+        $this->om->flush();
+        $rootId = $root->getId();
+        $this->om->clear();
+
+        $queries = [];
+        $this->om->getConfiguration()->setLoggerCallable(
+            static function (array $q) use (&$queries) { $queries[] = $q; }
+        );
+
+        $loadedRoot = $this->om->createQueryBuilder(ChainNode::class)
+            ->field('id')->equals($rootId)
+            ->includeKey('first')
+            ->includeKey('second')
+            ->getQuery()
+            ->getSingleResult();
+
+        $this->assertNotNull($loadedRoot);
+        $this->assertCount(1, $queries, 'Multi-include must collapse into one Parse query');
+
+        $first  = $loadedRoot->getFirst();
+        $second = $loadedRoot->getSecond();
+
+        $this->assertNotNull($first);
+        $this->assertNotNull($second);
+        $this->assertSame('A', $first->getLabel());
+        $this->assertSame('B', $second->getLabel());
+
+        $this->assertSame(
+            ChainNode::class,
+            get_class($first),
+            'root.first must be the entity class'
+        );
+        $this->assertSame(
+            ChainNode::class,
+            get_class($second),
+            'root.second must be the entity class even though its id was first seen as a nested Pointer inside root.first'
+        );
+
+        $this->assertSame(
+            $second,
+            $first->getFirst(),
+            'A.first must be the same instance as root.second (identity preserved)'
+        );
+
+        $this->assertCount(1, $queries, 'No extra query may fire while reading the included graph');
+    }
+}

--- a/tests/Models/Blog/ChainNode.php
+++ b/tests/Models/Blog/ChainNode.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Models\Blog;
+
+use Redking\ParseBundle\Mapping\Annotations as ORM;
+
+/**
+ * Self-referencing fixture used to exercise the multi-includeKey hydration
+ * path where a Pointer field nested inside one top-level include refers to
+ * the entity provided by a sibling top-level include.
+ */
+#[ORM\ParseObject(collection: "blog_chain_node")]
+class ChainNode
+{
+    use \Redking\ParseBundle\ObjectTrait;
+
+    #[ORM\Field(type: "string")]
+    private ?string $label = null;
+
+    #[ORM\ReferenceOne(targetDocument: self::class)]
+    private ?ChainNode $first = null;
+
+    #[ORM\ReferenceOne(targetDocument: self::class)]
+    private ?ChainNode $second = null;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    public function setLabel(?string $label): self
+    {
+        $this->label = $label;
+
+        return $this;
+    }
+
+    public function getFirst(): ?ChainNode
+    {
+        return $this->first;
+    }
+
+    public function setFirst(?ChainNode $first): self
+    {
+        $this->first = $first;
+
+        return $this;
+    }
+
+    public function getSecond(): ?ChainNode
+    {
+        return $this->second;
+    }
+
+    public function setSecond(?ChainNode $second): self
+    {
+        $this->second = $second;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Multi-includeKey queries used to fire one extra Parse request per second-and-following relation, and returned those relations as still- lazy __CG__\... proxies instead of the entity class.

- UnitOfWork::getOrCreateObject now flips var-exporter ghosts to INITIALIZED_FULL before re-hydrating, so RuntimeReflectionProperty and downstream __set calls (e.g. ACLTrait::setPublicAcl) stop re-triggering the lazy loader.
- ParseObjectHydrator::hydrate pre-registers concrete instances for every fully-available association, so nested Pointer fields resolve via getReference() to the entity class instead of locking a proxy into the identity map.