### PR TITLE
Fix aggregation pipeline transform for Parse Server 6 (stage-aware)

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -540,31 +540,100 @@ class QueryBuilder
     }
 
     /**
-     * Replace aggregate previous stage names and id for Parse Server > 6 (should be native mongodb syntax)
+     * Aggregation pipeline stage names supported by Parse Server / MongoDB.
+     *
+     * On Parse Server < 6, the pipeline accepted bare stage names (e.g. "match")
+     * and "objectId" as the id field. On Parse Server >= 6 the native MongoDB
+     * syntax is expected: stage names prefixed with "$" and "_id" as the id field.
+     *
+     * @var string[]
+     */
+    private static $aggregateStageNames = [
+        'project', 'group', 'match', 'lookup', 'unwind', 'sort',
+        'skip', 'limit', 'count', 'facet', 'addFields', 'set', 'unset',
+        'replaceRoot', 'sortByCount', 'sample', 'redact', 'graphLookup',
+        'bucket', 'bucketAuto',
+    ];
+
+    /**
+     * Convert a Parse Server < 6 aggregation pipeline to the native MongoDB
+     * syntax expected by Parse Server >= 6.
+     *
+     * Two distinct rules apply and must not be mixed up:
+     *  - Stage names are prefixed with "$", but ONLY when they appear as pipeline
+     *    stages (top level, list elements, or inside a $lookup sub-pipeline). This
+     *    prevents output fields that happen to share a stage name (e.g. a "count"
+     *    field produced by a $group) from being wrongly renamed to "$count".
+     *  - "objectId" keys are renamed to "_id" everywhere inside a stage body, since
+     *    the Parse object id is stored as "_id" in MongoDB.
      */
     public static function getAggregateForNewParseVersion(array $pipeline): array
     {
-        $replacements = [
-            'project' => '$project',
-            'group' => '$group',
-            'match' => '$match',
-            'lookup' => '$lookup',
-            'unwind' => '$unwind',
-            'sort' => '$sort',
-            'objectId' => '_id'
-        ];
+        return self::transformAggregateStages($pipeline);
+    }
 
-        $newArray = [];
+    /**
+     * Transform a pipeline (an associative array of stage => body, or a list of
+     * single-stage documents). Only keys recognized as stage names are prefixed.
+     */
+    private static function transformAggregateStages(array $pipeline): array
+    {
+        $result = [];
         foreach ($pipeline as $key => $value) {
-            $newKey = $replacements[$key] ?? $key;
-            if (is_array($value)) {
-                $newArray[$newKey] = self::getAggregateForNewParseVersion($value);
+            if (is_int($key)) {
+                // List form: each element is itself a stage document.
+                $result[$key] = is_array($value) ? self::transformAggregateStages($value) : $value;
+            } elseif (in_array($key, self::$aggregateStageNames, true)) {
+                $newKey = '$' . $key;
+                if ('lookup' === $key && is_array($value)) {
+                    $result[$newKey] = self::transformLookupStage($value);
+                } elseif (is_array($value)) {
+                    $result[$newKey] = self::transformAggregateFields($value);
+                } else {
+                    $result[$newKey] = $value;
+                }
             } else {
-                $newArray[$newKey] = $value;
+                // Unknown key at pipeline level: keep it but still apply field rules.
+                $result[$key] = is_array($value) ? self::transformAggregateFields($value) : $value;
             }
         }
 
-        return $newArray;
+        return $result;
+    }
+
+    /**
+     * Transform the body of a stage: rename "objectId" keys to "_id" recursively,
+     * without ever prefixing stage names (output fields are preserved verbatim).
+     */
+    private static function transformAggregateFields(array $body): array
+    {
+        $result = [];
+        foreach ($body as $key => $value) {
+            $newKey = 'objectId' === $key ? '_id' : $key;
+            $result[$newKey] = is_array($value) ? self::transformAggregateFields($value) : $value;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Transform a $lookup stage: its "pipeline" key holds a nested pipeline whose
+     * stage names must be prefixed, while the other keys (from, localField,
+     * foreignField, as, let, ...) follow the field rules.
+     */
+    private static function transformLookupStage(array $lookup): array
+    {
+        $result = [];
+        foreach ($lookup as $key => $value) {
+            if ('pipeline' === $key && is_array($value)) {
+                $result[$key] = self::transformAggregateStages($value);
+            } else {
+                $newKey = 'objectId' === $key ? '_id' : $key;
+                $result[$newKey] = is_array($value) ? self::transformAggregateFields($value) : $value;
+            }
+        }
+
+        return $result;
     }
 
     public function getLimit(): ?int

--- a/tests/Functional/QueryAggregateTest.php
+++ b/tests/Functional/QueryAggregateTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Redking\ParseBundle\Tests\Functional;
+
+use Redking\ParseBundle\Tests\Models\Blog\BankOperation;
+use Redking\ParseBundle\Tests\Models\Blog\Post;
+use Redking\ParseBundle\Tests\Models\Blog\User;
+
+/**
+ * Functional coverage for aggregation pipelines executed against a real Parse
+ * Server. These golden-value tests must pass identically on Parse Server 4.5.2
+ * (legacy pipeline syntax) and >= 6.x (native MongoDB syntax), proving that
+ * QueryBuilder::getAggregateForNewParseVersion() preserves results across the
+ * migration. Each test mirrors a pipeline pattern used in production services.
+ */
+class QueryAggregateTest extends \Redking\ParseBundle\Tests\TestCase
+{
+    protected static $modelSets = [
+        'Redking\ParseBundle\Tests\Models\Blog\User',
+        'Redking\ParseBundle\Tests\Models\Blog\Post',
+        'Redking\ParseBundle\Tests\Models\Blog\BankOperation',
+    ];
+
+    private function createUser(string $name): User
+    {
+        $user = new User();
+        $user->setPassword('p4ss');
+        $user->setName($name);
+        $this->om->persist($user);
+
+        return $user;
+    }
+
+    private function createPost(string $text, User $user): Post
+    {
+        $post = new Post();
+        $post->setText($text);
+        $post->setUser($user);
+        $this->om->persist($post);
+
+        return $post;
+    }
+
+    private function createBankOperation(float $amount): BankOperation
+    {
+        $op = new BankOperation();
+        $op->setAmount($amount);
+        $this->om->persist($op);
+
+        return $op;
+    }
+
+    /**
+     * Index aggregation results by their group id, returned under the "objectId"
+     * key by Parse Server on both versions. Accepts array or object rows.
+     */
+    private function indexByObjectId(array $results): array
+    {
+        $indexed = [];
+        foreach ($results as $row) {
+            $row = (array) $row;
+            $indexed[$row['objectId']] = $row;
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * Pattern: $substr extraction of a pointer id ($_p_user) + $group by the
+     * extracted id + conditional $cond/$sum counting. Mirrors the reporting
+     * pipelines that group by establishment/adherent ids.
+     */
+    public function testSubstrPointerExtractionWithConditionalCount(): void
+    {
+        $userA = $this->createUser('UserA');
+        $userB = $this->createUser('UserB');
+        $this->om->flush();
+
+        $this->createPost('ham', $userA);
+        $this->createPost('ham', $userA);
+        $this->createPost('spam', $userA);
+        $this->createPost('ham', $userB);
+        $this->createPost('spam', $userB);
+        $this->om->flush();
+
+        $pipeline = [
+            'project' => [
+                'objectId' => 1,
+                'text' => 1,
+                'userId' => ['$substr' => ['$_p_user', strlen('_User$'), -1]],
+            ],
+            'group' => [
+                'objectId' => '$userId',
+                'nbPosts' => ['$sum' => 1],
+                'nbHam' => ['$sum' => ['$cond' => [['$eq' => ['$text', 'ham']], 1, 0]]],
+            ],
+        ];
+
+        $results = $this->om->getRepository(Post::class)
+            ->createQueryBuilder()
+            ->aggregate($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $byUser = $this->indexByObjectId($results);
+
+        $this->assertCount(2, $byUser);
+        $this->assertArrayHasKey($userA->getId(), $byUser);
+        $this->assertArrayHasKey($userB->getId(), $byUser);
+        $this->assertSame(3, (int) $byUser[$userA->getId()]['nbPosts']);
+        $this->assertSame(2, (int) $byUser[$userA->getId()]['nbHam']);
+        $this->assertSame(2, (int) $byUser[$userB->getId()]['nbPosts']);
+        $this->assertSame(1, (int) $byUser[$userB->getId()]['nbHam']);
+    }
+
+    /**
+     * Production pipelines reference a pointer either by its Parse field name
+     * ("user") or by its raw Mongo name ("_p_user"), often mixed in the same
+     * pipeline. Parse Server must translate the Parse field name to the Mongo
+     * name inside $match on BOTH versions, otherwise such matches would silently
+     * return nothing on Parse 6. This locks that behaviour down.
+     */
+    public function testMatchOnPointerByParseFieldName(): void
+    {
+        $userA = $this->createUser('UserA');
+        $this->om->flush();
+
+        $this->createPost('a', $userA);
+        $this->createPost('b', $userA);
+        $this->createPost('c', $userA);
+        $this->om->flush();
+
+        $pipeline = [
+            'match' => ['user' => ['$ne' => null]],
+            'group' => ['objectId' => null, 'nb' => ['$sum' => 1]],
+        ];
+
+        $results = $this->om->getRepository(Post::class)
+            ->createQueryBuilder()
+            ->aggregate($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame(3, (int) ((array) $results[0])['nb']);
+    }
+
+    /**
+     * Same as above but referencing the raw Mongo pointer field "_p_user".
+     */
+    public function testMatchOnPointerByRawMongoFieldName(): void
+    {
+        $userA = $this->createUser('UserA');
+        $this->om->flush();
+
+        $this->createPost('a', $userA);
+        $this->createPost('b', $userA);
+        $this->createPost('c', $userA);
+        $this->om->flush();
+
+        $pipeline = [
+            'match' => ['_p_user' => ['$ne' => null]],
+            'group' => ['objectId' => null, 'nb' => ['$sum' => 1]],
+        ];
+
+        $results = $this->om->getRepository(Post::class)
+            ->createQueryBuilder()
+            ->aggregate($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $this->assertCount(1, $results);
+        $this->assertSame(3, (int) ((array) $results[0])['nb']);
+    }
+
+    /**
+     * Pattern: $match with $in + single $group (objectId => null) summing
+     * conditional counters. Mirrors global reporting totals.
+     */
+    public function testMatchInWithGlobalConditionalSums(): void
+    {
+        $userA = $this->createUser('UserA');
+        $this->om->flush();
+
+        $this->createPost('ham', $userA);
+        $this->createPost('ham', $userA);
+        $this->createPost('spam', $userA);
+        $this->createPost('other', $userA);
+        $this->om->flush();
+
+        $pipeline = [
+            'match' => ['text' => ['$in' => ['ham', 'spam']]],
+            'group' => [
+                'objectId' => null,
+                'total' => ['$sum' => 1],
+                'nbSpam' => ['$sum' => ['$cond' => [['$eq' => ['$text', 'spam']], 1, 0]]],
+            ],
+        ];
+
+        $results = $this->om->getRepository(Post::class)
+            ->createQueryBuilder()
+            ->aggregate($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $this->assertCount(1, $results);
+        $row = (array) $results[0];
+        $this->assertSame(3, (int) $row['total']);
+        $this->assertSame(1, (int) $row['nbSpam']);
+    }
+
+    /**
+     * Pattern: $group summing a numeric field. Mirrors invoice/amount totals.
+     */
+    public function testGroupSumOfNumericField(): void
+    {
+        $this->createBankOperation(10.0);
+        $this->createBankOperation(20.0);
+        $this->createBankOperation(30.0);
+        $this->createBankOperation(40.0);
+        $this->om->flush();
+
+        $pipeline = [
+            'group' => [
+                'objectId' => null,
+                'totalAmount' => ['$sum' => '$amount'],
+                'nb' => ['$sum' => 1],
+            ],
+        ];
+
+        $results = $this->om->getRepository(BankOperation::class)
+            ->createQueryBuilder()
+            ->aggregate($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $this->assertCount(1, $results);
+        $row = (array) $results[0];
+        $this->assertSame(100.0, (float) $row['totalAmount']);
+        $this->assertSame(4, (int) $row['nb']);
+    }
+
+    /**
+     * Pattern: $sort + $skip + $limit pagination. Mirrors the paginated export
+     * pipelines (skip/limit stages were previously not converted for Parse 6).
+     */
+    public function testSortSkipLimitPagination(): void
+    {
+        $this->createBankOperation(10.0);
+        $this->createBankOperation(20.0);
+        $this->createBankOperation(30.0);
+        $this->createBankOperation(40.0);
+        $this->om->flush();
+
+        $pipeline = [
+            'sort' => ['amount' => 1],
+            'skip' => 1,
+            'limit' => 2,
+        ];
+
+        $results = $this->om->getRepository(BankOperation::class)
+            ->createQueryBuilder()
+            ->aggregate($pipeline)
+            ->getQuery()
+            ->execute();
+
+        $this->assertCount(2, $results);
+        $amounts = array_map(fn ($row) => (float) ((array) $row)['amount'], $results);
+        $this->assertSame([20.0, 30.0], $amounts);
+    }
+}

--- a/tests/Unit/QueryBuilderAggregateTest.php
+++ b/tests/Unit/QueryBuilderAggregateTest.php
@@ -70,4 +70,84 @@ class QueryBuilderAggregateTest extends TestCase
     {
         $this->assertSame([], QueryBuilder::getAggregateForNewParseVersion([]));
     }
+
+    public function testSkipAndLimitStagesArePrefixed(): void
+    {
+        $out = QueryBuilder::getAggregateForNewParseVersion([
+            'sort' => ['createdAt' => -1],
+            'skip' => 20,
+            'limit' => 10,
+        ]);
+
+        $this->assertSame(
+            ['$sort' => ['createdAt' => -1], '$skip' => 20, '$limit' => 10],
+            $out
+        );
+    }
+
+    public function testCountStageIsPrefixed(): void
+    {
+        $out = QueryBuilder::getAggregateForNewParseVersion([
+            'count' => 'total',
+        ]);
+
+        $this->assertSame(['$count' => 'total'], $out);
+    }
+
+    /**
+     * A field named like a stage and produced as a $group output (e.g. "count")
+     * must NOT be turned into a stage operator ("$count").
+     */
+    public function testStageNamedOutputFieldInGroupIsPreserved(): void
+    {
+        $out = QueryBuilder::getAggregateForNewParseVersion([
+            'group' => [
+                'objectId' => '$category',
+                'count' => ['$sum' => 1],
+                'limit' => ['$max' => '$value'],
+            ],
+        ]);
+
+        $this->assertSame(
+            ['$group' => [
+                '_id' => '$category',
+                'count' => ['$sum' => 1],
+                'limit' => ['$max' => '$value'],
+            ]],
+            $out
+        );
+    }
+
+    /**
+     * objectId used as a value reference (e.g. "$factures.objectId") is a scalar,
+     * not a key, and must be left untouched by the key-renaming rules.
+     */
+    public function testObjectIdAsValueReferenceIsPreserved(): void
+    {
+        $out = QueryBuilder::getAggregateForNewParseVersion([
+            'unwind' => '$factures',
+            'group' => ['objectId' => '$factures.objectId'],
+        ]);
+
+        $this->assertSame(
+            ['$unwind' => '$factures', '$group' => ['_id' => '$factures.objectId']],
+            $out
+        );
+    }
+
+    public function testListFormPipelineIsTransformed(): void
+    {
+        $out = QueryBuilder::getAggregateForNewParseVersion([
+            ['match' => ['status' => 'active']],
+            ['group' => ['objectId' => '$type', 'count' => ['$sum' => 1]]],
+        ]);
+
+        $this->assertSame(
+            [
+                ['$match' => ['status' => 'active']],
+                ['$group' => ['_id' => '$type', 'count' => ['$sum' => 1]]],
+            ],
+            $out
+        );
+    }
 }


### PR DESCRIPTION
Only prefix stage names where they are real pipeline stages (top level, list elements, $lookup sub-pipelines), add the missing skip/limit/count/... stages, and stop renaming stage-named output fields (e.g. a $group "count"). Add unit and functional coverage asserting golden results match on 4.5.2 and 6.1.0.